### PR TITLE
Tree helper functions

### DIFF
--- a/utilities/tree-ds.metta
+++ b/utilities/tree-ds.metta
@@ -6,7 +6,7 @@
 (: NilList TreeList)
 (: ConsTree (-> Tree TreeList TreeList))
 
-;; (: ROOT NodeType)
+(: ROOT NodeType)
 (: AND NodeType)
 (: OR NodeType)
 (: NOT NodeType)
@@ -20,17 +20,21 @@
 (: TreeNode (-> NodeValue Tree Tree TreeList TreeList Tree))
 
 ;; (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))
-(:buildTree (-> Expression Tree))
+(: buildTree (-> Expression Tree))
 (= (buildTree $expr) 
   (case $expr
     (
-      ;; ( (ROOT $a $b) (TreeNode (Value Nil False ROOT) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (AND $a $b) (TreeNode (Value Nil False AND) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (OR $a $b) (TreeNode (Value Nil False OR) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (NOT $x) (TreeNode (Value Nil False NOT) (buildTree $x) NilNode NilList NilList) )
-      ( $symbol (TreeNode (Value $symbol False NOT) NilNode NilNode NilList NilList) )
+      ( $symbol (TreeNode (Value $symbol False LITERAL) NilNode NilNode NilList NilList) )
     )
   )
+)
+
+;; (: buildTreeWithRoot (-> Expression Tree))
+(= (buildTreeWithRoot $expr)
+  (TreeNode (Value Nil False ROOT) NilNode (buildTree $b) NilList NilList)
 )
 
 ;; !(buildTree (AND a b))

--- a/utilities/tree-ds.metta
+++ b/utilities/tree-ds.metta
@@ -19,8 +19,7 @@
 ;; TreeNode(nodeValue, leftChild, rightChild, guardSet, listOfChildren)
 (: TreeNode (-> NodeValue Tree Tree TreeList TreeList Tree))
 
-;; (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))
-;; (: buildTree (-> Expression Tree))
+;; function to build a tree of type "Tree" from an expression
 (= (buildTree $expr) 
   (case $expr
     (
@@ -32,11 +31,27 @@
   )
 )
 
-;; (: buildTreeWithRoot (-> Expression Tree))
+;; function to build a tree with a root node of "ROOT"
 (= (buildTreeWithRoot $expr)
   (TreeNode (Value Nil False ROOT) NilNode (buildTree $b) NilList NilList)
 )
 
-;; !(buildTree (AND 1 2))
-;; !(buildTree (AND a b))
+(: getNodeChildren (-> Tree TreeList))
+(= (getNodeChildren $node)
+  (case $node
+    (
+      ( (TreeNode $nodeVal $leftNode $rightNode $guardSet $children) $children )
+    )
+  )
+)
+
+(: getNodeGuardSet (-> Tree TreeList))
+(= (getNodeGuardSet $node)
+  (case $node
+    (
+      ( (TreeNode $nodeVal $leftNode $rightNode $guardSet $children) $guardSet )
+    )
+  )
+)
+
 !(buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A))))))))

--- a/utilities/tree-ds.metta
+++ b/utilities/tree-ds.metta
@@ -24,9 +24,9 @@
 (= (buildTree $expr) 
   (case $expr
     (
-      ( (AND $a $b) (TreeNode (Value 0 False AND) (buildTree $a) (buildTree $b) NilList NilList) )
+      ( (AND $a $b) (TreeNode (Value Nil False AND) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (OR $a $b) (TreeNode (Value Nil False OR) (buildTree $a) (buildTree $b) NilList NilList) )
-      ( (NOT $x) (TreeNode (Value Nil False NOT) (buildTree $x) NilNode NilList NilList) )
+      ( (NOT $x) (TreeNode (Value Nil False NOT) NilNode (buildTree $x) NilList NilList) )
       ( $symbol (TreeNode (Value $symbol False LITERAL) NilNode NilNode NilList NilList) )
     )
   )

--- a/utilities/tree-ds.metta
+++ b/utilities/tree-ds.metta
@@ -13,18 +13,18 @@
 (: LITERAL NodeType)
 
 ;; Value(value, truthValue, nodeType)
-(: Value (-> Symbol Bool NodeType NodeValue))
+(: Value (-> Number Bool NodeType NodeValue))
 
 (: NilNode Tree)
 ;; TreeNode(nodeValue, leftChild, rightChild, guardSet, listOfChildren)
 (: TreeNode (-> NodeValue Tree Tree TreeList TreeList Tree))
 
 ;; (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))
-(: buildTree (-> Expression Tree))
+;; (: buildTree (-> Expression Tree))
 (= (buildTree $expr) 
   (case $expr
     (
-      ( (AND $a $b) (TreeNode (Value Nil False AND) (buildTree $a) (buildTree $b) NilList NilList) )
+      ( (AND $a $b) (TreeNode (Value 0 False AND) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (OR $a $b) (TreeNode (Value Nil False OR) (buildTree $a) (buildTree $b) NilList NilList) )
       ( (NOT $x) (TreeNode (Value Nil False NOT) (buildTree $x) NilNode NilList NilList) )
       ( $symbol (TreeNode (Value $symbol False LITERAL) NilNode NilNode NilList NilList) )
@@ -37,5 +37,6 @@
   (TreeNode (Value Nil False ROOT) NilNode (buildTree $b) NilList NilList)
 )
 
+;; !(buildTree (AND 1 2))
 ;; !(buildTree (AND a b))
 !(buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A))))))))

--- a/utilities/tree-ds.metta
+++ b/utilities/tree-ds.metta
@@ -13,7 +13,7 @@
 (: LITERAL NodeType)
 
 ;; Value(value, truthValue, nodeType)
-(: Value (-> Number Bool NodeType NodeValue))
+(: Value (-> $v Bool NodeType NodeValue))
 
 (: NilNode Tree)
 ;; TreeNode(nodeValue, leftChild, rightChild, guardSet, listOfChildren)

--- a/utilities/tree.metta
+++ b/utilities/tree.metta
@@ -1,0 +1,39 @@
+! (register-module! ../../metta-moses-reduction)
+! (import! &self metta-moses-reduction:utilities:tree-ds)
+
+(: (-> (-> Number Number Number) Number Number))
+(= (treeFoldl $func $acc NilNode) $acc)
+(= (treeFoldl $func $acc (TreeNode $nodeVal $leftTree $rightTree $guardSet $children))
+  (let $leftAcc
+    (case $leftTree
+      (
+        ( (NilNode) 0 )
+        ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
+          (case $innerNodeVal
+            (
+              ( (Value Nil $truthVal $type) 0 )
+              ( (Value $val $truthVal $type) (treeFoldl $func ($func $acc $val) $innerLeftTree) )
+            )
+          )
+        )
+      )
+    )
+    (case $rightTree
+      (
+        ( (NilNode) 0 )
+        ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
+          (case $innerNodeVal
+            (
+              ( (Value Nil $truthVal $type) 0 )
+              ( (Value $val $truthVal $type) (treeFoldl $func ($func $leftAcc $val) $innerRightTree) )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+(= (add $x $y) (+ $x $y))
+
+!(treeFoldl add 0 (buildTree (AND 1 2)))

--- a/utilities/tree.metta
+++ b/utilities/tree.metta
@@ -3,36 +3,45 @@
 
 (= (treeFoldl $func $acc NilNode) $acc)
 (= (treeFoldl $func $acc (TreeNode $nodeVal $leftTree $rightTree $guardSet $children))
-  (let $leftAcc
-    (case $leftTree
-      (
-        ( (NilNode) $acc )
-        ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
-          (case $innerNodeVal
-            (
-              ( (Value Nil $truthVal $type) $acc )
-              ( (Value $val $truthVal $type) (treeFoldl $func ($func $acc $val) $innerLeftTree) )
-            )
-          )
-        )
+  (case $nodeVal
+    (
+      ( (Value $val $truthVal LITERAL) 
+        ($func $acc $val)
       )
-    )
-    (case $rightTree
-      (
-        ( (NilNode) $acc )
-        ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
-          (case $innerNodeVal
-            (
-              ( (Value Nil $truthVal $type) $acc )
-              ( (Value $val $truthVal $type) (treeFoldl $func ($func $leftAcc $val) $innerRightTree) )
-            )
-          )
-        )
+      ( (Value $val $truthVal ROOT)
+        (treeFoldl $func $acc $rightTree)
+      )
+      ( (Value $val $truthVal NOT)
+        (treeFoldl $func $acc $rightTree)
+      )
+      ( (Value $val $truthVal AND)
+        (treeFoldl $func (treeFoldl $func $acc $leftTree) $rightTree)
+      )
+      ( (Value $val $truthVal OR)
+        (treeFoldl $func (treeFoldl $func $acc $leftTree) $rightTree)
       )
     )
   )
 )
 
-(= (add $x $y) (+ $x $y))
+(= (treeFoldr $func $acc NilNode) $acc)
+(= (treeFoldr $func $acc (TreeNode $nodeVal $leftTree $rightTree $guardSet $children))
+  (case $nodeVal
+    (
+      ( (Value $val $truthVal LITERAL) ($func $acc $val) )
+      ( (Value $val $truthVal ROOT) (treeFoldl $func $acc $rightTree) )
+      ( (Value $val $truthVal NOT) (treeFoldl $func $acc $rightTree) )
+      ( (Value $val $truthVal AND)
+        (treeFoldl $func (treeFoldl $func $acc $leftTree) $rightTree)
+      )
+      ( (Value $val $truthVal OR)
+        (treeFoldl $func (treeFoldl $func $acc $leftTree) $rightTree)
+      )
+    )
+  )
+)
 
-!(treeFoldl add 0 (buildTree (AND 1 2)))
+;; (= (zip $x $y) ($x $y))
+
+;; !(treeFoldl zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
+;; !(treeFoldr zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))

--- a/utilities/tree.metta
+++ b/utilities/tree.metta
@@ -1,17 +1,16 @@
 ! (register-module! ../../metta-moses-reduction)
 ! (import! &self metta-moses-reduction:utilities:tree-ds)
 
-(: (-> (-> Number Number Number) Number Number))
 (= (treeFoldl $func $acc NilNode) $acc)
 (= (treeFoldl $func $acc (TreeNode $nodeVal $leftTree $rightTree $guardSet $children))
   (let $leftAcc
     (case $leftTree
       (
-        ( (NilNode) 0 )
+        ( (NilNode) $acc )
         ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
           (case $innerNodeVal
             (
-              ( (Value Nil $truthVal $type) 0 )
+              ( (Value Nil $truthVal $type) $acc )
               ( (Value $val $truthVal $type) (treeFoldl $func ($func $acc $val) $innerLeftTree) )
             )
           )
@@ -20,11 +19,11 @@
     )
     (case $rightTree
       (
-        ( (NilNode) 0 )
+        ( (NilNode) $acc )
         ( (TreeNode $innerNodeVal $innerLeftTree $innerRightTree $innerGuardSet $innerChildren) 
           (case $innerNodeVal
             (
-              ( (Value Nil $truthVal $type) 0 )
+              ( (Value Nil $truthVal $type) $acc )
               ( (Value $val $truthVal $type) (treeFoldl $func ($func $leftAcc $val) $innerRightTree) )
             )
           )


### PR DESCRIPTION
This pull request contains the following changes and implementations

Changes:

- added `ROOT` node type to the custom tree data structure
- changed `NOT` implementation while building tree
- added `LITERAL` implementation while building tree
- changed nodeValue to accept any data types as the value for tree `LITERAL`

Implementations:

- implemented `foldl` helper function for tree data structure
- implemented `foldr` helper function for tree data structure
- implemented `getNodeGuardSet` to get the guard sets of a given node
- implemented `getNodeChildren` to get thechildren of a given node