### PR TITLE
Fix import alias bug

### DIFF
--- a/utilities/expression-helpers.metta
+++ b/utilities/expression-helpers.metta
@@ -1,7 +1,3 @@
-! (register-module! ../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:types)
-! (import! &self metta-moses-reduction:utilities:list-helpers)
-
 (=(isEmpty $exp)
   (if (== Nil $exp) True False)
 )
@@ -28,7 +24,7 @@
       (Nil True)
       ((Cons $x $xs)
         (if (== $x True)
-          (n-ary-and $xs)
+          (nAryAnd $xs)
           False
         )
       )
@@ -43,7 +39,7 @@
       ((Cons $x $xs)
         (if (== $x True)
           True
-          (n-ary-or $xs)
+          (nAryOr $xs)
         )
       )
     )

--- a/utilities/list-helpers.metta
+++ b/utilities/list-helpers.metta
@@ -1,6 +1,3 @@
-! (register-module! ../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:types)
-
 ; Function to find the length of a list
 (:length (-> (List $t) Number))
 (= (length Nil) 0)

--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -1,7 +1,3 @@
-! (register-module! ../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:types)
-! (import! &self metta-moses-reduction:utilities:list-helpers)
-
 ;; -----------------------------------
 ;; -----------------------------------
 ;; -------- function to build a tree of type "Tree" from an expression

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -3,6 +3,7 @@
 ! (import! &self metta-moses-reduction:utilities:expression-helpers)
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
+
 ;; -----------------------------------
 ;; -----------------------------------
 ;; Test cases for experssion-helpers.metta


### PR DESCRIPTION
The bug was happening due to incorrect order of import and MeTTa doesn't allow that.
Keep in mind that importing in MeTTa means copying the code from the source file (target of the import) and pasting it to the current file.