### PR TITLE
refactor: relocated functions to tree-helpers.metta

### DIFF
--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -1,6 +1,6 @@
 ! (register-module! ../../metta-moses-reduction)
 ! (import! &self metta-moses-reduction:types)
-! (import! &self metta-moses-reduction:utilities:list-helpers)
+; ! (import! &self metta-moses-reduction:utilities:list-helpers)
 
 ;; -----------------------------------
 ;; -----------------------------------
@@ -214,3 +214,36 @@
     )
   )
 )
+
+(: allExceptTargetType (-> (List Tree) NodeType (List Tree)))
+(= (allExceptTargetType Nil $nodeType) Nil)
+(= (allExceptTargetType $treeList $nodeType) (
+      let  (Cons $tree $rest) $treeList (
+          unify $tree  (TreeNode (Value $value $truthValue $nodeType) $guardSet $children)
+          (allExceptTargetType $rest $nodeType)
+          (Cons $tree (allExceptTargetType $rest $nodeType))
+      )
+))
+
+
+
+; below are helper functions for DELETE AND and OR subtree handlers
+(: delete_AND_SubTree (-> Tree Tree) )
+(= (delete_AND_SubTree Nil) Nil )
+(= (delete_AND_SubTree $tree) (
+
+        let (TreeNode $nodeValue $guardSet $children) $tree
+        (TreeNode $nodeValue $guardSet (allExceptTargetType $children AND))
+
+    ))
+
+(: delete_OR_SubTree (-> Tree Tree) )
+(= (delete_OR_SubTree Nil) Nil )
+(= (delete_OR_SubTree $tree) (
+
+        let (TreeNode $nodeValue $guardSet $children) $tree
+        (TreeNode $nodeValue $guardSet (allExceptTargetType $children OR))
+
+    ))
+
+

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -233,3 +233,36 @@
 
 ;; !(treeFoldl zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
 ;; !(treeFoldr zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
+
+
+;;[TEST]  ! (----  allExceptTargetType ----)
+;  ! (allExceptTargetType
+; (Cons
+;     (TreeNode (Value Nil False AND) Nil Nil)
+;     (Cons
+;         (TreeNode (Value target1 False NOT)  Nil Nil)
+;         (Cons
+;             (TreeNode (Value target2 True OR) Nil Nil)
+;             Nil
+;         )
+; )
+; )
+;  NOT ;this is the nodeType
+;  )
+;;[EXPECT] [(Cons (TreeNode (Value Nil False AND) Nil Nil) (Cons (TreeNode (Value target2 True OR) Nil Nil) Nil))]
+
+
+
+
+;;   [TEST] remove-AND-subTree/ remove-OR-subTree
+;  ! (delete_AND_SubTree (TreeNode (Value target1 False NOT) Nil (Cons
+;              (TreeNode (Value Nil False AND) Nil Nil)
+;              (Cons
+;                  (TreeNode (Value target1 False OR)  Nil Nil)
+;                  (Cons
+;                      (TreeNode (Value target2 True AND) Nil Nil)
+;                      Nil
+;                  )
+;          )
+;  ) ))
+;; [EXPECT] [(TreeNode (Value target1 False NOT) Nil (Cons (TreeNode (Value target1 False OR) Nil Nil) Nil))]


### PR DESCRIPTION
This pull request introduces the following functions
- AllExceptTargetType : accepts a list of trees and a node type  ,  and returns all the elements of the list except those with the same node type.
- delete_OR_subTree/delete_AND_subTree :  accept a tree and correspondingly a tree with children except OR and AND type