### PR TITLE
Added disconnectSubTreeHandler function

### DIFF
--- a/enf-reducer/RTEHelpers.metta
+++ b/enf-reducer/RTEHelpers.metta
@@ -1,0 +1,18 @@
+! (register-module! ../../metta-moses-reduction)
+! (import! &self metta-moses-reduction:types)
+! (import! &self metta-moses-reduction:utilities:list-helpers)
+! (import! &self metta-moses-reduction:utilities:tree-helpers)
+
+
+;a funcion to remove a child from a tree's listOfChildren and return an updated tree
+(=(disconnectSubTreeHandler $child $tree)
+ (case ($child $tree)
+  (
+    (($child (TreeNode $nodeValue $leftChild $rightChild $guardSet $listOfChildren))
+     (TreeNode $nodeValue $leftChild $rightChild $guardSet (compareAndRemoveNode $child $listOfChildren NilList))
+    )
+    ($else ())
+  )
+ )
+)
+

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -3,6 +3,7 @@
 ! (import! &self metta-moses-reduction:utilities:expression-helpers)
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
+! (import! &self metta-moses-reduction:enf-reducer:RTEHelpers)
 
 ;; -----------------------------------
 ;; -----------------------------------
@@ -234,3 +235,11 @@
 
 ;; !(treeFoldl zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
 ;; !(treeFoldr zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
+
+;; -----------------------------------
+;; -----------------------------------
+;; Test cases for RTEHelpers.metta
+;; -----------------------------------
+;; -----------------------------------
+
+; !(disconnectSubTreeHandler (buildTree (OR a (AND b c))) (TreeNode (Value Nil False OR) (TreeNode (Value a False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value Nil False AND) (TreeNode (Value b False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value c False LITERAL) NilNode NilNode NilList NilList) NilList NilList) NilList (ConsTree (buildTree (OR a (AND b c))) (ConsTree (buildTree (AND a (AND b c))) NilList))))


### PR DESCRIPTION
- Created a new file inside the enf-reducer folder called 'RTEHelpers'
- Added a function called disconnetSubTreeHandler inside the new file
- The function takes a child and a tree, removes the child from the tree's listOfChildren, and returns the updated tree
- Added a test case for the function inside the utilityTests file