### PR TITLE
Re-implement functions for new tree structure

### DIFF
--- a/enf-reducer/RTEHelpers.metta
+++ b/enf-reducer/RTEHelpers.metta
@@ -1,0 +1,18 @@
+! (register-module! ../../metta-moses-reduction)
+! (import! &self metta-moses-reduction:types)
+! (import! &self metta-moses-reduction:utilities:list-helpers)
+! (import! &self metta-moses-reduction:utilities:tree-helpers)
+
+
+;a funcion to remove a child from a tree's listOfChildren and return an updated tree
+(=(disconnectSubTreeHandler $child $tree)
+ (case ($child $tree)
+  (
+    (($child (TreeNode $nodeValue $leftChild $rightChild $guardSet $listOfChildren))
+     (TreeNode $nodeValue $leftChild $rightChild $guardSet (compareAndRemoveNode $child $listOfChildren NilList))
+    )
+    ($else ())
+  )
+ )
+)
+

--- a/enf-reducer/RTEHelpers.metta
+++ b/enf-reducer/RTEHelpers.metta
@@ -1,18 +1,12 @@
-! (register-module! ../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:types)
-! (import! &self metta-moses-reduction:utilities:list-helpers)
-! (import! &self metta-moses-reduction:utilities:tree-helpers)
-
-
 ;a funcion to remove a child from a tree's listOfChildren and return an updated tree
-(=(disconnectSubTreeHandler $child $tree)
- (case ($child $tree)
-  (
-    (($child (TreeNode $nodeValue $leftChild $rightChild $guardSet $listOfChildren))
-     (TreeNode $nodeValue $leftChild $rightChild $guardSet (compareAndRemoveNode $child $listOfChildren NilList))
-    )
-    ($else ())
+(: (-> Tree Tree Tree))
+(=(disconnectSubTreeHandler Nil $tree) $tree)
+(=(disconnectSubTreeHandler $child Nil) Nil)
+(=(disconnectSubTreeHandler $child (TreeNode $nodeValue $guardSet $children))
+  (TreeNode 
+    $nodeValue 
+    $guardSet 
+    (compareAndRemoveNode $child $children Nil)
   )
- )
 )
 

--- a/utilities/list-helpers.metta
+++ b/utilities/list-helpers.metta
@@ -122,7 +122,7 @@
 (= (quickSort Nil) Nil)
 (= (quickSort (Cons $x $xs))
     (let ($left $right) (partition $x $xs)
-        (append (quickSort $left) (Cons $x (quickSort $right)))
+        (extend (quickSort $left) (Cons $x (quickSort $right)))
     )
 )
 
@@ -175,7 +175,7 @@
 
 (:unionSet (-> (List $t) (List $t) (List $t) (List $t)))
 (=(unionSet $list1 $list2)
-    (removeDuplicates (append $list1 $list2))
+    (removeDuplicates (extend $list1 $list2))
 )
 
 (:isSubset (-> (List $t) (List $t) Bool))

--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -85,7 +85,7 @@
 
 (:appendChild (-> Tree Tree Tree))
 (= (appendChild (TreeNode $nodeValue $guardSet $children) $child)
-  (TreeNode $nodeValue $guardSet (Cons $child $children))
+  (TreeNode $nodeValue $guardSet (Cons $children $child))
 )
 
 
@@ -148,27 +148,17 @@
 )
 
 (:compareTrees (-> Tree Tree Bool))
-(=(compareTrees $tree1 $tree2)
-    (case ($tree1 $tree2) (
-        (((TreeNode (Value $symbol $constraint $nodetype) $leftChild $rightChild $guardSet $listOfChildren) (TreeNode (Value $symbol $constraint $nodetype)  $leftChild1 $rightChild1 $guardSet1 $listOfChildren1)) True)
-        ($else False)
-    )
-    )
+(=(compareTrees $fstTree $sndTree)
+  (if (nodeEquality $fstTree $sndTree) True False)
 )
 
-(:compareAndRemoveNode (-> Tree TreeList TreeList TreeList))
-(=(compareAndRemoveNode $tree $treeList $accumulator)
-    (case $treeList(
-            ((ConsTree $x $xs)
-                (if (== (compareTrees $tree $x) True)
-                    (compareAndRemoveNode $tree $xs $accumulator)
-                    (compareAndRemoveNode $tree $xs (appendTree $accumulator (ConsTree $x NilList)))
-                )
-            )
-            ($_  $accumulator)
-
-        )
-    )
+(:compareAndRemoveNode (-> Tree (List Tree) (List Tree) (List Tree)))
+(=(compareAndRemoveNode $tree Nil $accumulator) $accumulator)
+(=(compareAndRemoveNode $tree (Cons $x $xs) $accumulator)
+  (if (compareTrees $tree $x)
+    (compareAndRemoveNode $tree $xs $accumulator)
+    (compareAndRemoveNode $tree $xs (extend $accumulator (Cons $x Nil)))
+  )
 )
 
 (= (treeFoldl $func $acc NilNode) $acc)

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -3,6 +3,7 @@
 ! (import! &self metta-moses-reduction:utilities:expression-helpers)
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
+! (import! &self metta-moses-reduction:enf-reducer:RTEHelpers)
 
 ;; -----------------------------------
 ;; -----------------------------------
@@ -234,3 +235,11 @@
 
 ;; !(treeFoldl zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
 ;; !(treeFoldr zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
+
+;; -----------------------------------
+;; -----------------------------------
+;; Test cases for RTEHelpers.metta
+;; -----------------------------------
+;; -----------------------------------
+
+; !(disconnectSubTreeHandler (buildTree (OR a (AND b c))) (TreeNode (Value Nil False OR) (TreeNode (Value a False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value Nil False AND) (TreeNode (Value b False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value c False LITERAL) NilNode NilNode NilList NilList) NilList NilList) NilList (ConsTree (buildTree (OR a (AND b c))) (ConsTree (buildTree (AND a (AND b c))) NilList))))

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -242,4 +242,17 @@
 ;; -----------------------------------
 ;; -----------------------------------
 
-; !(disconnectSubTreeHandler (buildTree (OR a (AND b c))) (TreeNode (Value Nil False OR) (TreeNode (Value a False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value Nil False AND) (TreeNode (Value b False LITERAL) NilNode NilNode NilList NilList) (TreeNode (Value c False LITERAL) NilNode NilNode NilList NilList) NilList NilList) NilList (ConsTree (buildTree (OR a (AND b c))) (ConsTree (buildTree (AND a (AND b c))) NilList))))
+!(disconnectSubTreeHandler 
+  (buildTree (OR a (AND b c))) 
+  (TreeNode 
+    (Value Nil False OR)
+    Nil
+    (Cons 
+      (buildTree (OR a (AND b c))) 
+      (Cons 
+        (buildTree (AND a (AND b c)))
+        Nil
+      )
+    )
+  )
+)


### PR DESCRIPTION
The following changes has been made:

- re-implement `disconnectSubTreeHandler`, `compareTrees`, `compareAndRemoveNode` functions to work for the new tree structure