### PR TITLE
Apply and cut implementation

### DIFF
--- a/enf-reducer/RTEHelpers.metta
+++ b/enf-reducer/RTEHelpers.metta
@@ -15,21 +15,23 @@
 ;; The function returns the updated  tree and the boolean value together in a tuple.
 
 (: applyAndCut (-> Tree Tree (Tree Bool)))
-(= (applyAndCut $grandChild $child) (
+(= (applyAndCut $grandChild $child)
   (if (and (== (length (getChildren $grandChild)) 1) (== (getGuardSet $grandChild) Nil))
-     (if (>= length (getChildren (head (getChildren $grandChild))) 0)
+     (if (>= (length (getChildren (head (getChildren $grandChild)))) 0)
         (let* 
           (
             ($firstNodeOfGrandChild (head (getChildren $grandChild)))
             ($updatedChildrenTree (replaceChildren $child (extend (getChildren $child) (getChildren $firstNodeOfGrandChild))))
-            ($finalUpdatedTree (replaceChildren $updatedChildrenTree (findAndRemoveTree (getChildren $updatedChildrenTree) $firstNodeOfGrandChild)))
-            ($hasTerminalAndNode (containsTerminalNode $finalUpdatedTree))
-          ) 
+            ($finalUpdatedTree (replaceChildren $updatedChildrenTree (findAndRemoveTree $firstNodeOfGrandChild (getChildren $updatedChildrenTree) )))
+            ($hasTerminalAndNode (containsTerminalAndNode (getChildren $firstNodeOfGrandChild)))
+          )
           ($finalUpdatedTree $hasTerminalAndNode)
         )
         ($child False)
      )
      ($child False)
   )
-))
+)
+
+
 

--- a/enf-reducer/RTEHelpers.metta
+++ b/enf-reducer/RTEHelpers.metta
@@ -1,5 +1,5 @@
 ;a funcion to remove a child from a tree's listOfChildren and return an updated tree
-(: (-> Tree Tree Tree))
+(: disconnectSubTreeHandler (-> Tree Tree Tree))
 (=(disconnectSubTreeHandler Nil $tree) $tree)
 (=(disconnectSubTreeHandler $child Nil) Nil)
 (=(disconnectSubTreeHandler $child (TreeNode $nodeValue $guardSet $children))
@@ -9,4 +9,27 @@
     (compareAndRemoveNode $child $children Nil)
   )
 )
+
+;; A function that applies the "ApplyAndCut" operation on a tree node. It is the reimplementation of the function found in python.
+;; The function takes a treeNode and checks if it has only one child and no guardSet, if so, it merges the child and the current node as one. It also checks the existance of a terminal and node in the child of the tree which will be beneficial for the `andSubTreeElegance` function. 
+;; The function returns the updated  tree and the boolean value together in a tuple.
+
+(: applyAndCut (-> Tree Tree (Tree Bool)))
+(= (applyAndCut $grandChild $child) (
+  (if (and (== (length (getChildren $grandChild)) 1) (== (getGuardSet $grandChild) Nil))
+     (if (>= length (getChildren (head (getChildren $grandChild))) 0)
+        (let* 
+          (
+            ($firstNodeOfGrandChild (head (getChildren $grandChild)))
+            ($updatedChildrenTree (replaceChildren $child (extend (getChildren $child) (getChildren $firstNodeOfGrandChild))))
+            ($finalUpdatedTree (replaceChildren $updatedChildrenTree (findAndRemoveTree (getChildren $updatedChildrenTree) $firstNodeOfGrandChild)))
+            ($hasTerminalAndNode (containsTerminalNode $finalUpdatedTree))
+          ) 
+          ($finalUpdatedTree $hasTerminalAndNode)
+        )
+        ($child False)
+     )
+     ($child False)
+  )
+))
 

--- a/utilities/list-helpers.metta
+++ b/utilities/list-helpers.metta
@@ -228,22 +228,14 @@
     )
 )
 
-(:hasTerminalNode (-> Tree Bool))
-(= (hasTerminalNode NilNode) False)
-(= (hasTerminalNode $node) (
-    case $node (
-        ( (TreeNode (Value $value $truthValue AND) NilNode NilNode $guardSet NilList) (
-            unify $guardSet (ConsTree $singleNode NilList) True False
-        ) )
-        ( (TreeNode $nodeValue $left $right $guardSet $children) ( or (hasTerminalNode $left) (hasTerminalNode $right)) )
+(: containsTerminalAndNode (-> (List Tree) Bool))
+(= (containsTerminalAndNode Nil) False)
+(= (containsTerminalAndNode (Cons $x $xs))
+  (case $x
+    (
+      ((TreeNode (Value $value $truthValue AND) (Cons $y Nil) Nil) True)
+      ((TreeNode $nodeValue $guardSet $children) (containsTerminalAndNode $xs))
     )
-))
+  )
+)
 
-(:containsTerminalNode (-> TreeList Bool ))
-(= (containsTerminalNode NilList) False)
-(= (containsTerminalNode $treeList) (
-    case $treeList (
-        ( (ConsTree $t $ts) (or (hasTerminalNode $t) (trace! (evaluating $ts ) (containsTerminalNode $ts))) )
-        ; ($else (Invalid Expression--- $else))
-    )
-))

--- a/utilities/list-helpers.metta
+++ b/utilities/list-helpers.metta
@@ -113,6 +113,16 @@
         (Cons $x (findAndRemove $elem $xs)))
 )
 
+;;function to find a given node from a list of nodes and remove it. Similar to findAndRemove implementation of for the lists.
+(: findAndRemoveTree (-> Tree (List Tree) (List Tree)))
+(= (findAndRemoveTree $elem Nil) Nil)
+(= (findAndRemoveTree $elem (Cons $x $xs))
+    (if (isNodeEqual $x $elem) 
+        (findAndRemoveTree $elem $xs)
+        (Cons $x (findAndRemoveTree $elem $xs))
+    )
+)
+
 ; A function to compare 2 lists
 (:compare (-> (List $t) (List $t) (Bool)))
  ;; if both the lists are empty, They are the same.

--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -100,6 +100,15 @@
   (== $nodeValue1 $nodeValue2)
 )
 
+;;function to find a given node from a list of nodes and remove it. Similar to findAndRemove implementation of for the lists.
+(: findAndRemoveTree (-> Tree (List Tree) (List Tree)))
+(= (findAndRemoveTree $elem Nil) Nil)
+(= (findAndRemoveTree $elem (Cons $x $xs))
+    (if (isNodeEqual $x $elem) 
+        (findAndRemoveTree $elem $xs)
+        (Cons $x (findAndRemoveTree $elem $xs))
+    )
+)
 ;;function to check if a tree is member of a treelist
 (:treeIsMember (-> Tree (List Tree) Bool))
 (= (treeIsMember $x $list)

--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -100,15 +100,6 @@
   (== $nodeValue1 $nodeValue2)
 )
 
-;;function to find a given node from a list of nodes and remove it. Similar to findAndRemove implementation of for the lists.
-(: findAndRemoveTree (-> Tree (List Tree) (List Tree)))
-(= (findAndRemoveTree $elem Nil) Nil)
-(= (findAndRemoveTree $elem (Cons $x $xs))
-    (if (isNodeEqual $x $elem) 
-        (findAndRemoveTree $elem $xs)
-        (Cons $x (findAndRemoveTree $elem $xs))
-    )
-)
 ;;function to check if a tree is member of a treelist
 (:treeIsMember (-> Tree (List Tree) Bool))
 (= (treeIsMember $x $list)

--- a/utilities/tree-helpers.metta
+++ b/utilities/tree-helpers.metta
@@ -128,6 +128,10 @@
 (= (replaceGuardSet NilNode $newguardSet) NilNode)
 (= (replaceGuardSet (TreeNode $value $guardSet $children) $newguardSet) (TreeNode $value $newguardSet $children))
 
+(: replaceChildren (-> Tree (List Tree) Tree))
+(= (replaceChildren NilNode $newChildren) NilNode)
+(= (replaceChildren (TreeNode $value $guardSet $children) $newChildren) (TreeNode $value $guardSet $newChildren))
+
 (:replaceNodeValue (-> Tree NodeValue Tree))
 (= (replaceNodeValue $tree $newValue)
     (let ($value $left $right $guardSet $children) 

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -1,6 +1,6 @@
 ! (register-module! ../../metta-moses-reduction)
 ! (import! &self metta-moses-reduction:types)
-! (import! &self metta-moses-reduction:utilities:expression-helpers)
+; ! (import! &self metta-moses-reduction:utilities:expression-helpers)
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
 ! (import! &self metta-moses-reduction:enf-reducer:RTEHelpers)
@@ -437,3 +437,11 @@
 
 ;; !(containsTerminalAndNode (Cons (TreeNode (Value Nil False AND) (Cons (TreeNode (Value A False LITERAL) Nil Nil) Nil) Nil) Nil))
 ;; !(containsTerminalAndNode (Cons (TreeNode (Value Nil False OR) Nil Nil) Nil))
+
+;;!(applyAndCut 
+;;      (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value A False AND) Nil Nil) (Cons (TreeNode (Value B False AND) Nil Nil) Nil))) Nil))
+;;      (TreeNode (Value Nil False OR) Nil (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value A False AND) Nil Nil) (Cons (TreeNode (Value B False AND) Nil Nil) Nil))) Nil)) (Cons (TreeNode (Value A False AND) Nil Nil) (Cons (TreeNode (Value B False AND) Nil Nil) Nil)))))
+
+;;!(applyAndCut 
+;;    (TreeNode (Value Nil False OR) Nil (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value A False AND) Nil Nil) Nil)) (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value B False AND) Nil Nil) Nil)) Nil)))
+;;    (TreeNode (Value Nil False AND) (Cons (TreeNode (Value B False AND) Nil Nil) Nil) (Cons (TreeNode (Value Nil False OR) Nil (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value A False AND) Nil Nil) Nil)) (Cons (TreeNode (Value Nil False AND) Nil (Cons (TreeNode (Value B False AND) Nil Nil) Nil)) Nil))) Nil)))

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -434,3 +434,6 @@
 ;;     )
 ;;   )
 ;; )
+
+;; !(containsTerminalAndNode (Cons (TreeNode (Value Nil False AND) (Cons (TreeNode (Value A False LITERAL) Nil Nil) Nil) Nil) Nil))
+;; !(containsTerminalAndNode (Cons (TreeNode (Value Nil False OR) Nil Nil) Nil))


### PR DESCRIPTION
- Implemented apply and cut operation according to the logic found on the python implementation. Fixed the type definition mistake on the `disconnectSubTreeHandler` function.
- Added `findAndRemove` function for list of trees and a `replaceChildren` function.
- Added test cases for the apply and cut operation.
- Removed import from expression helper module in the utilities metta file due to naming conflict of similar function in the tree helper functions which led to unwanted non determinism.

It's better to view the PR starting from the `list-helpers.metta` file and then go to the `RTEHelpers.metta` file.