### PR TITLE
Refactored ContainsTerminalNode 

### DIFF
--- a/utilities/expression-helpers.metta
+++ b/utilities/expression-helpers.metta
@@ -83,7 +83,7 @@
 (= (getGuardSet $exp)
   (case $exp 
     (
-      (
+      (fold
         ($OP $exp1 $exp2)
         (let* 
           (

--- a/utilities/list-helpers.metta
+++ b/utilities/list-helpers.metta
@@ -1,3 +1,7 @@
+! (register-module! ../../metta-moses-reduction)
+! (import! &self metta-moses-reduction:types)
+! (import! &self metta-moses-reduction:utilities:expression-helpers)
+
 ; Function to find the length of a list
 (:length (-> (List $t) Number))
 (= (length Nil) 0)
@@ -229,21 +233,21 @@
 )
 
 (:hasTerminalNode (-> Tree Bool))
-(= (hasTerminalNode NilNode) False)
+(= (hasTerminalNode Nil) False)
 (= (hasTerminalNode $node) (
     case $node (
-        ( (TreeNode (Value $value $truthValue AND) NilNode NilNode $guardSet NilList) (
-            unify $guardSet (ConsTree $singleNode NilList) True False
+        ( (TreeNode (Value $value $truthValue AND) $guardSet Nil) (
+            unify $guardSet (Cons $singleNode Nil) True False
         ) )
-        ( (TreeNode $nodeValue $left $right $guardSet $children) ( or (hasTerminalNode $left) (hasTerminalNode $right)) )
+        ( (TreeNode $nodeValue $guardSet $children) (nAryOr (map hasTerminalNode $children)) )
     )
 ))
 
-(:containsTerminalNode (-> TreeList Bool ))
-(= (containsTerminalNode NilList) False)
+(:containsTerminalNode (-> (List Tree) Bool ))
+(= (containsTerminalNode Nil) False)
 (= (containsTerminalNode $treeList) (
     case $treeList (
-        ( (ConsTree $t $ts) (or (hasTerminalNode $t) (trace! (evaluating $ts ) (containsTerminalNode $ts))) )
+        ( (Cons $t $ts) (or (hasTerminalNode $t) (containsTerminalNode $ts)) )
         ; ($else (Invalid Expression--- $else))
     )
 ))

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -258,7 +258,7 @@
 
 ; !(compareAndRemoveNode (buildTree (OR a (AND b c))) (ConsTree (buildTree (OR a (AND b c))) (ConsTree (buildTree (AND a (AND b c))) NilList)) NilList)
 
-;; (= (zip $x $y) ($x $y))
+; (= (zip $x $y) ($x $y))
 
 ;; !(treeFoldl zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))
 ;; !(treeFoldr zip Nil (buildTree (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A)))))))))

--- a/utilities/utility-tests.metta
+++ b/utilities/utility-tests.metta
@@ -434,3 +434,101 @@
 ;;     )
 ;;   )
 ;; )
+
+
+
+; !(hasTerminalNode (TreeNode (Value "A" True AND) Nil Nil)) ; Should return False
+; !(hasTerminalNode 
+;   (TreeNode (Value Nil True AND) (Cons (TreeNode (Value x True LITERAL) Nil Nil) Nil) Nil)
+;     ) 
+;; [EXPECT] True
+
+
+; !(hasTerminalNode 
+;     (TreeNode (Value Nil True OR) 
+;         (Cons 
+;             (TreeNode (Value x True LITERAL) Nil Nil) 
+;             (Cons 
+;                 (TreeNode (Value x True LITERAL) Nil Nil) 
+;                 Nil
+;             ) 
+;         ) 
+;         (Cons 
+;             (TreeNode (Value Nil True OR) 
+;                 (Cons 
+;                     (TreeNode (Value x True LITERAL) Nil Nil) 
+;                     Nil
+;                 ) 
+;                 (Cons 
+;                     (TreeNode (Value x True LITERAL) Nil Nil) 
+;                     (Cons 
+;                         (TreeNode (Value Nil True AND) ;;here is the terminal node
+;                             (Cons 
+;                                 (TreeNode (Value x True LITERAL) Nil Nil) 
+;                                 Nil
+;                             ) 
+;                             Nil
+;                         ) 
+;                         Nil
+;                     )
+;                 )
+;             ) 
+;             Nil
+;         )
+;     )
+; ) 
+;; [EXPECT] True
+
+
+; Test 1: List with one Tree containing an AND node with no children
+; !(containsTerminalNode 
+;   (Cons 
+;     (TreeNode (Value "A" True AND) Nil Nil) 
+;     Nil)) 
+;; [EXPECT] False
+
+; Test 2: List with one Tree containing a LITERAL node
+
+; !(containsTerminalNode 
+;   (Cons 
+;     (TreeNode 
+;       (Value Nil True AND) 
+;       (Cons 
+;         (TreeNode (Value x True LITERAL) Nil Nil) 
+;         Nil) 
+;       Nil) 
+;     Nil))
+;; [EXPECT] True
+
+
+; Test 3: List with multiple Trees, one containing a terminal node
+; !(containsTerminalNode 
+;   (Cons 
+;     (TreeNode 
+;       (Value Nil True OR) 
+;       (Cons 
+;         (TreeNode (Value x True LITERAL) Nil Nil) 
+;         (Cons 
+;           (TreeNode (Value x True LITERAL) Nil Nil) 
+;           Nil)) 
+;       (Cons 
+;         (TreeNode 
+;           (Value Nil True OR) 
+;           (Cons 
+;             (TreeNode (Value x True LITERAL) Nil Nil) 
+;             Nil) 
+;           (Cons 
+;             (TreeNode (Value x True LITERAL) Nil Nil) 
+;             (Cons 
+;               (TreeNode 
+;                 (Value Nil True AND) 
+;                 (Cons 
+;                   (TreeNode (Value x True LITERAL) Nil Nil) 
+;                   Nil) 
+;                 Nil) 
+;               Nil))) 
+;         Nil)) 
+;     (Cons 
+;       (TreeNode (Value "A" True AND) Nil Nil) 
+;       Nil))) 
+;; [EXPECT] True


### PR DESCRIPTION
This pull request introduces the following changes to `list-helpers.metta`
- refactored the functions `hasTerminalNode` and `containsTerminalNode` according to the new structure.
- updated the test cases for these functions under `unility-tests.metta`.