### PR TITLE
Implemented the Delete-Inconsistent-Handle Transformation

### DIFF
--- a/enf-reducer/delete-inconsistent-handle.metta
+++ b/enf-reducer/delete-inconsistent-handle.metta
@@ -1,0 +1,36 @@
+! (register-module! ../../metta-moses-reduction)
+! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
+! (import! &self metta-moses-reduction:utilities:general-helper-functions)
+
+(= (deleteInconsistent $exp)
+    (let*
+        (
+            ($guardSet (getGuardSetExp $exp ()))
+            ($isConsistent (isConsistentExp $guardSet))
+        )
+    (case $head
+        (
+            (AND (if $isConsistent $exp ()))
+            (OR $exp)
+            (NOT $exp)
+        )
+)
+)
+)
+
+;Testcases
+;Test 01 - for an empty set
+ ! (assertEqualToResult (deleteInconsistent ()) ( ()))
+ 
+;Test 02 - for OR and NOT expressions
+ ! (assertEqualToResult (deleteInconsistent (NOT (OR A B) (AND A B))) ( (NOT (OR A B) (AND A B))))
+ ! (assertEqualToResult (deleteInconsistent (OR A B (not A))) ( (OR A B (not A))))
+ ! (assertEqualToResult (deleteInconsistent (OR (AND A B) (AND A B) (not A))) ( (OR (AND A B) (AND A B) (not A))))
+
+;Test 03 - for different AND expressions
+ ! (assertEqualToResult (deleteInconsistent (AND (OR A B) (AND A B) A B)) ( (AND (OR A B) (AND A B) A B)))
+ ! (assertEqualToResult (deleteInconsistent (AND (not A) (not B) A)) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (AND A B) (OR A B) (not B))) ( (AND A (AND A B) (OR A B) (not B))))
+ ! (assertEqualToResult (deleteInconsistent (AND (AND A B) A)) ( (AND (AND A B) A)))
+ ! (assertEqualToResult (deleteInconsistent (AND A B (not B))) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (not A) (not B))) ( ()))

--- a/enf-reducer/delete-inconsistent-handle.metta
+++ b/enf-reducer/delete-inconsistent-handle.metta
@@ -1,7 +1,3 @@
-! (register-module! ../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
-! (import! &self metta-moses-reduction:utilities:general-helper-functions)
-
 (= (deleteInconsistent $exp)
     (let*
         (
@@ -18,19 +14,3 @@
 )
 )
 
-;Testcases
-;Test 01 - for an empty set
- ! (assertEqualToResult (deleteInconsistent ()) ( ()))
- 
-;Test 02 - for OR and NOT expressions
- ! (assertEqualToResult (deleteInconsistent (NOT (OR A B) (AND A B))) ( (NOT (OR A B) (AND A B))))
- ! (assertEqualToResult (deleteInconsistent (OR A B (not A))) ( (OR A B (not A))))
- ! (assertEqualToResult (deleteInconsistent (OR (AND A B) (AND A B) (not A))) ( (OR (AND A B) (AND A B) (not A))))
-
-;Test 03 - for different AND expressions
- ! (assertEqualToResult (deleteInconsistent (AND (OR A B) (AND A B) A B)) ( (AND (OR A B) (AND A B) A B)))
- ! (assertEqualToResult (deleteInconsistent (AND (not A) (not B) A)) ( ()))
- ! (assertEqualToResult (deleteInconsistent (AND A (AND A B) (OR A B) (not B))) ( (AND A (AND A B) (OR A B) (not B))))
- ! (assertEqualToResult (deleteInconsistent (AND (AND A B) A)) ( (AND (AND A B) A)))
- ! (assertEqualToResult (deleteInconsistent (AND A B (not B))) ( ()))
- ! (assertEqualToResult (deleteInconsistent (AND A (not A) (not B))) ( ()))

--- a/enf-reducer/rte-helpers.metta
+++ b/enf-reducer/rte-helpers.metta
@@ -367,3 +367,19 @@
 )
 )
 )
+
+;a function to check whether an n-ary expression is consistent or not.
+(= (isConsistentExp $exp)
+(let $guardSetTuple (getGuardSetExp $exp ()) 
+(if (== $guardSetTuple ()) True
+        (let*
+            (
+                ($head (car-atom $guardSetTuple))
+                ($tail (cdr-atom $guardSetTuple))
+            )
+        (if (isMember (Not $head) $tail) False
+            (isConsistentExp $tail)
+        ))
+)
+)   
+)

--- a/enf-reducer/rte-helpers.metta
+++ b/enf-reducer/rte-helpers.metta
@@ -339,3 +339,31 @@
 (= (mapChild $function $secondArg (Cons $x $xs))
       (Cons ($function $secondArg $x) (mapChild $function $secondArg $xs))
 )
+
+; a function to get the guardset of an n-ary expression as a tuple. 
+(= (getGuardSetExp $exp $acc)
+    (if (== $exp ()) $acc
+        (let*
+            (
+                ($head (car-atom $exp))
+                ($headIsExpression (== (get-metatype $head) Expression))
+                ($tail (cdr-atom $exp))
+            )
+        (if (or (== $head OR)(== $head NOT)) ()
+            (if (== $head AND )
+                (getGuardSetExp $tail $acc)
+                (if $headIsExpression
+                    (case $head
+                        (
+                            ( (not $a) (getGuardSetExp $tail (cons-atom $head $acc)))
+                            ($else (getGuardSetExp $tail $acc))
+                        )
+                )
+            (getGuardSetExp $tail (cons-atom $head $acc))
+        )
+)
+)
+
+)
+)
+)

--- a/enf-reducer/tests/delete-inconsistent-test.metta
+++ b/enf-reducer/tests/delete-inconsistent-test.metta
@@ -1,0 +1,21 @@
+! (register-module! ../../../metta-moses-reduction) 
+! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
+! (import! &self metta-moses-reduction:utilities:general-helper-functions)
+! (import! &self metta-moses-reduction:enf-reducer:delete-inconsistent-handle)
+
+;Testcases
+;Test 01 - for an empty set
+ ! (assertEqualToResult (deleteInconsistent ()) ( ()))
+ 
+;Test 02 - for OR and NOT expressions
+ ! (assertEqualToResult (deleteInconsistent (NOT (OR A B) (AND A B))) ( (NOT (OR A B) (AND A B))))
+ ! (assertEqualToResult (deleteInconsistent (OR A B (not A))) ( (OR A B (not A))))
+ ! (assertEqualToResult (deleteInconsistent (OR (AND A B) (AND A B) (not A))) ( (OR (AND A B) (AND A B) (not A))))
+
+;Test 03 - for different AND expressions
+ ! (assertEqualToResult (deleteInconsistent (AND (OR A B) (AND A B) A B)) ( (AND (OR A B) (AND A B) A B)))
+ ! (assertEqualToResult (deleteInconsistent (AND (not A) (not B) A)) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (AND A B) (OR A B) (not B))) ( (AND A (AND A B) (OR A B) (not B))))
+ ! (assertEqualToResult (deleteInconsistent (AND (AND A B) A)) ( (AND (AND A B) A)))
+ ! (assertEqualToResult (deleteInconsistent (AND A B (not B))) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (not A) (not B))) ( ()))

--- a/enf-reducer/tests/helper-functions-test.metta
+++ b/enf-reducer/tests/helper-functions-test.metta
@@ -101,3 +101,21 @@
 ; Test 04
 ; Create a single TreeNode object
 ! (assertEqual (isConsistent (Cons (TreeNode ( Value A True LITERAL) Nil Nil) Nil)) True)
+
+; Test for getGuardSetExp
+
+;Test 01 - getGuardSet of an empty set
+! (assertEqualToResult (getGuardSetExp () ()) (()))
+
+;Test 02 - getGuardSet of OR and NOT expressions 
+! (assertEqualToResult (getGuardSetExp (OR A B (not A)) ()) (()))
+! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (not A)) ()) (()))
+! (assertEqualToResult (getGuardSetExp (NOT (OR A B) (AND A B) A B) ()) (()))
+
+;Test 03 - getGuardSet of AND expressions
+! (assertEqualToResult (getGuardSetExp (AND (not A) (not B) A) ()) ((A (not B) (not A))))
+! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (not B)) ()) (((not B) A)))
+! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) ()) ((A)))
+! (assertEqualToResult (getGuardSetExp (AND A B (not B)) ()) (((not B) B A)))
+! (assertEqualToResult (getGuardSetExp (AND A (not A) (not B)) ()) (((not B) (not A) A)))
+! (assertEqualToResult (getGuardSetExp (AND (not A) A B) ()) ((B A (not A))))

--- a/enf-reducer/tests/helper-functions-test.metta
+++ b/enf-reducer/tests/helper-functions-test.metta
@@ -2,6 +2,7 @@
 ! (import! &self metta-moses-reduction:types) 
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
+! (import! &self metta-moses-reduction:utilities:general-helper-functions)
 ! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
 ! (import! &self metta-moses-reduction:enf-reducer:propagate-truth-value)
 ! (import! &self metta-moses-reduction:enf-reducer:reduce-to-elegance)
@@ -119,3 +120,16 @@
 ! (assertEqualToResult (getGuardSetExp (AND A B (not B)) ()) (((not B) B A)))
 ! (assertEqualToResult (getGuardSetExp (AND A (not A) (not B)) ()) (((not B) (not A) A)))
 ! (assertEqualToResult (getGuardSetExp (AND (not A) A B) ()) ((B A (not A))))
+
+;Test for isConsistentExp 
+
+ ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
+ ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B))) (True))
+ ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
+ ! (assertEqualToResult (isConsistentExp (AND (not A) (not B) A)) (False))
+ ! (assertEqualToResult (isConsistentExp (AND A (AND A B) (OR A B) (not B))) (True))
+ ! (assertEqualToResult (isConsistentExp (AND (AND A B) A)) (True))
+ ! (assertEqualToResult (isConsistentExp (AND A B (not B))) (False))
+ ! (assertEqualToResult (isConsistentExp (OR A B (not A))) (True))
+ ! (assertEqualToResult (isConsistentExp (OR (AND A B) (AND A B) (not A))) (True))
+ ! (assertEqualToResult (isConsistentExp (AND A (not A) (not B))) (False))

--- a/enf-reducer/tests/helper-functions-test.metta
+++ b/enf-reducer/tests/helper-functions-test.metta
@@ -1,5 +1,5 @@
 ! (register-module! ../../../metta-moses-reduction)
-! (import! &self metta-moses-reduction:types) 
+;! (import! &self metta-moses-reduction:types) 
 ! (import! &self metta-moses-reduction:utilities:list-helpers)
 ! (import! &self metta-moses-reduction:utilities:tree-helpers)
 ! (import! &self metta-moses-reduction:utilities:general-helper-functions)

--- a/utilities/general-helper-functions.metta
+++ b/utilities/general-helper-functions.metta
@@ -32,3 +32,18 @@
 )
 ) 
 
+; a helper function to the isConsistentExp function.
+; a function which checks if an element is member of a tuple.
+(= (isMember $x $tuple)
+    (if (== $tuple ()) False
+        (let*
+            (
+                ($head (car-atom $tuple))
+                ($tail (cdr-atom $tuple))
+            )
+        (
+            if (== $x $head) True (isMember $x $tail)
+        )
+)
+)
+)

--- a/utilities/general-helper-functions.metta
+++ b/utilities/general-helper-functions.metta
@@ -15,3 +15,20 @@
        )
    )
 )
+
+; a helper function to the isConsistentExp function.
+; a function which simplifies nested logical negations by reducing them to their simplest form. 
+(= (Not $a)
+    (if (== (get-metatype $a) Symbol)
+        (not $a)
+        (if (== (get-metatype $a) Expression)
+            (case $a
+                (
+                    ( (not $b) (if (== (get-metatype $b) Symbol) $b (Not $b)))
+                )
+        )
+    False
+)
+)
+) 
+

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -12,4 +12,6 @@
   ! (assertEqualToResult (Not (Not (Not A))) ( (not A)))
   ! (assertEqualToResult (Not (Not A)) (A))
 
-  
+; tests for the function 'isMember'
+! (assertEqualToResult (isMember 1 (1 2 3)) (True))
+! (assertEqualToResult (isMember 8 (1 2 3)) (False))

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -7,3 +7,9 @@
 !(assertEqualToResult (~= Something Nothing) (True))
 !(assertEqualToResult (~= Something Something) (False))
 !(assertEqualToResult (~= Something something) (True))
+
+; tests for the function 'Not' 
+  ! (assertEqualToResult (Not (Not (Not A))) ( (not A)))
+  ! (assertEqualToResult (Not (Not A)) (A))
+
+  


### PR DESCRIPTION
I implemented the delete-inconsistent-handle transformation. The function takes an expression and it either deletes it _(returns ( ))_ or keeps it _(returns the expression itself)_ depending on its consistency. The consistency of an expression is checked using the function `isConsistentExp` which uses the function `getGuardSetExp` to get the guardset of the expression and check for any inconsistencies.  