### PR TITLE
refactored getGuardSetExp 

### DIFF
--- a/enf-reducer/delete-inconsistent-handle.metta
+++ b/enf-reducer/delete-inconsistent-handle.metta
@@ -1,7 +1,7 @@
 (= (deleteInconsistent $exp)
     (let*
         (
-            ($guardSet (getGuardSetExp $exp ()))
+            ($guardSet (getGuardSetExp $exp $exp ()))
             ($isConsistent (isConsistentExp $guardSet))
         )
     (case $head

--- a/enf-reducer/rte-helpers.metta
+++ b/enf-reducer/rte-helpers.metta
@@ -341,36 +341,45 @@
 )
 
 ; a function to get the guardset of an n-ary expression as a tuple. 
-(= (getGuardSetExp $exp $acc)
-    (if (== $exp ()) $acc
+(= (getGuardSetExp $expOriginal $expRecursive $acc)
+    (if (== (get-metatype $expOriginal) Symbol) ($expOriginal) ;if $exp is LITERAL, the guardSet is the set containing the literal itself
+    (if (== $expRecursive ()) $acc
         (let*
             (
-                ($head (car-atom $exp))
+                ($head (car-atom $expRecursive))
                 ($headIsExpression (== (get-metatype $head) Expression))
-                ($tail (cdr-atom $exp))
+                ($tail (cdr-atom $expRecursive))
+                ($tailIsExpression (== (get-metatype $tail) Expression))
             )
-        (if (or (== $head OR)(== $head NOT)) ()
-            (if (== $head AND )
-                (getGuardSetExp $tail $acc)
-                (if $headIsExpression
-                    (case $head
-                        (
-                            ( (not $a) (getGuardSetExp $tail (cons-atom $head $acc)))
-                            ($else (getGuardSetExp $tail $acc))
-                        )
-                )
-            (getGuardSetExp $tail (cons-atom $head $acc))
+            (if (== $head NOT) 
+             (case $expOriginal
+                 (
+                     ((NOT $b) (if (== (get-metatype $b) Symbol) $expOriginal ())) ;If the head of the expression is NOT, $b should only be a literal for it to have a guardSet of (NOT $b). If $b is an expression, the guardSet is ()
+                 )
+             )
+             (if (== $head OR) ()  ;an OR expression doesn't have a guardSet
+                 (if (== $head AND) ; an AND expression has a guardSet which contains its literal and (NOT $literal) children
+                     (getGuardSetExp $expOriginal $tail $acc)
+                     (if $headIsExpression
+                         (case $head
+                             (
+                                 ( (NOT $a) (getGuardSetExp $expOriginal $tail (cons-atom $head $acc)))
+                                 ($else (getGuardSetExp $expOriginal $tail $acc))
+                             )
+                         )
+                         (getGuardSetExp $expOriginal $tail (cons-atom $head $acc))
+                     )
+                 )
+             )
+            )
         )
-)
-)
-
-)
-)
+    ) 
+    )
 )
 
 ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
-(let $guardSetTuple (getGuardSetExp $exp ()) 
+(let $guardSetTuple (getGuardSetExp $exp $exp ()) 
 (if (== $guardSetTuple ()) True
         (let*
             (

--- a/enf-reducer/tests/delete-inconsistent-test.metta
+++ b/enf-reducer/tests/delete-inconsistent-test.metta
@@ -2,20 +2,21 @@
 ! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
 ! (import! &self metta-moses-reduction:utilities:general-helper-functions)
 ! (import! &self metta-moses-reduction:enf-reducer:delete-inconsistent-handle)
-
 ;Testcases
-;Test 01 - for an empty set
+;Test 01 - for an empty set and literal
  ! (assertEqualToResult (deleteInconsistent ()) ( ()))
- 
+ ! (assertEqualToResult (deleteInconsistent (A)) ( (A)))
+ ! (assertEqualToResult (deleteInconsistent A) ( A))
 ;Test 02 - for OR and NOT expressions
- ! (assertEqualToResult (deleteInconsistent (NOT (OR A B) (AND A B))) ( (NOT (OR A B) (AND A B))))
- ! (assertEqualToResult (deleteInconsistent (OR A B (not A))) ( (OR A B (not A))))
- ! (assertEqualToResult (deleteInconsistent (OR (AND A B) (AND A B) (not A))) ( (OR (AND A B) (AND A B) (not A))))
+ ! (assertEqualToResult (deleteInconsistent (NOT (AND A B))) ((NOT (AND A B))))
+ ! (assertEqualToResult (deleteInconsistent (OR A B (NOT A))) ((OR A B (NOT A))))
+ ! (assertEqualToResult (deleteInconsistent (OR (AND A B) (AND A B) (NOT A))) ( (OR (AND A B) (AND A B) (NOT A))))
 
 ;Test 03 - for different AND expressions
+ ! (assertEqualToResult (deleteInconsistent (AND)) ( (AND)))
  ! (assertEqualToResult (deleteInconsistent (AND (OR A B) (AND A B) A B)) ( (AND (OR A B) (AND A B) A B)))
- ! (assertEqualToResult (deleteInconsistent (AND (not A) (not B) A)) ( ()))
- ! (assertEqualToResult (deleteInconsistent (AND A (AND A B) (OR A B) (not B))) ( (AND A (AND A B) (OR A B) (not B))))
+ ! (assertEqualToResult (deleteInconsistent (AND (NOT A) (NOT B) A)) (()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (AND A B) (OR A B) (NOT B))) ( (AND A (AND A B) (OR A B) (NOT B))))
  ! (assertEqualToResult (deleteInconsistent (AND (AND A B) A)) ( (AND (AND A B) A)))
- ! (assertEqualToResult (deleteInconsistent (AND A B (not B))) ( ()))
- ! (assertEqualToResult (deleteInconsistent (AND A (not A) (not B))) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A B (NOT B))) ( ()))
+ ! (assertEqualToResult (deleteInconsistent (AND A (NOT A) (NOT B))) ( ()))

--- a/enf-reducer/tests/helper-functions-test.metta
+++ b/enf-reducer/tests/helper-functions-test.metta
@@ -106,30 +106,35 @@
 ; Test for getGuardSetExp
 
 ;Test 01 - getGuardSet of an empty set
-! (assertEqualToResult (getGuardSetExp () ()) (()))
+! (assertEqualToResult (getGuardSetExp () () ()) (()))
+
+;Test 02 - getGuardSet of a literal
+! (assertEqualToResult (getGuardSetExp A A ()) ((A)))
+! (assertEqualToResult (getGuardSetExp (A) (A) ()) ((A)))
 
 ;Test 02 - getGuardSet of OR and NOT expressions 
-! (assertEqualToResult (getGuardSetExp (OR A B (not A)) ()) (()))
-! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (not A)) ()) (()))
-! (assertEqualToResult (getGuardSetExp (NOT (OR A B) (AND A B) A B) ()) (()))
+! (assertEqualToResult (getGuardSetExp (OR) (OR) ()) (()))
+! (assertEqualToResult (getGuardSetExp (OR A B (NOT A)) (OR A B (NOT A)) ()) (()))
+! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (NOT A)) (OR (AND A B) (AND A B) (NOT A)) ()) (()))
 
 ;Test 03 - getGuardSet of AND expressions
-! (assertEqualToResult (getGuardSetExp (AND (not A) (not B) A) ()) ((A (not B) (not A))))
-! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (not B)) ()) (((not B) A)))
-! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) ()) ((A)))
-! (assertEqualToResult (getGuardSetExp (AND A B (not B)) ()) (((not B) B A)))
-! (assertEqualToResult (getGuardSetExp (AND A (not A) (not B)) ()) (((not B) (not A) A)))
-! (assertEqualToResult (getGuardSetExp (AND (not A) A B) ()) ((B A (not A))))
+! (assertEqualToResult (getGuardSetExp (AND) (AND) ()) (()))
+! (assertEqualToResult (getGuardSetExp (AND A) (AND A) ()) ((A)))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) (NOT B) A) (AND (NOT A) (NOT B) A) ()) ((A (NOT B) (NOT A))))
+! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (NOT B)) (AND A (AND A B) (OR A B) (NOT B)) ()) (((NOT B) A)))
+! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) (AND (AND A B) A) ()) ((A)))
+! (assertEqualToResult (getGuardSetExp (AND A B (NOT B)) (AND A B (NOT B)) ()) (((NOT B) B A)))
+! (assertEqualToResult (getGuardSetExp (AND A (NOT A) (NOT B)) (AND A (NOT A) (NOT B)) ()) (((NOT B) (NOT A) A)))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) A B) (AND (NOT A) A B) ()) ((B A (NOT A))))
 
 ;Test for isConsistentExp 
-
+ ! (assertEqualToResult (isConsistentExp ()) (True))
+ ! (assertEqualToResult (isConsistentExp A) (True))
+ ! (assertEqualToResult (isConsistentExp (A)) (True))
+ ! (assertEqualToResult (isConsistentExp (AND)) (True))
  ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
- ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B))) (True))
- ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
- ! (assertEqualToResult (isConsistentExp (AND (not A) (not B) A)) (False))
- ! (assertEqualToResult (isConsistentExp (AND A (AND A B) (OR A B) (not B))) (True))
- ! (assertEqualToResult (isConsistentExp (AND (AND A B) A)) (True))
- ! (assertEqualToResult (isConsistentExp (AND A B (not B))) (False))
- ! (assertEqualToResult (isConsistentExp (OR A B (not A))) (True))
- ! (assertEqualToResult (isConsistentExp (OR (AND A B) (AND A B) (not A))) (True))
- ! (assertEqualToResult (isConsistentExp (AND A (not A) (not B))) (False))
+ ! (assertEqualToResult (isConsistentExp (AND (NOT A) (NOT B) A)) (False))
+ ! (assertEqualToResult (isConsistentExp (AND A B (NOT B))) (False))
+ ! (assertEqualToResult (isConsistentExp (OR A B (NOT A))) (True))
+ ! (assertEqualToResult (isConsistentExp (OR (AND A B) (AND A B) (NOT A))) (True))
+ ! (assertEqualToResult (isConsistentExp (AND A (NOT A) (NOT B))) (False))

--- a/utilities/general-helper-functions.metta
+++ b/utilities/general-helper-functions.metta
@@ -20,11 +20,11 @@
 ; a function which simplifies nested logical negations by reducing them to their simplest form. 
 (= (Not $a)
     (if (== (get-metatype $a) Symbol)
-        (not $a)
+        (NOT $a)
         (if (== (get-metatype $a) Expression)
             (case $a
                 (
-                    ( (not $b) (if (== (get-metatype $b) Symbol) $b (Not $b)))
+                    ( (NOT $b) (if (== (get-metatype $b) Symbol) $b (Not $b)))
                 )
         )
     False

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -9,7 +9,7 @@
 !(assertEqualToResult (~= Something something) (True))
 
 ; tests for the function 'Not' 
-  ! (assertEqualToResult (Not (Not (Not A))) ( (not A)))
+  ! (assertEqualToResult (Not (Not (Not A))) ((NOT A)))
   ! (assertEqualToResult (Not (Not A)) (A))
 
 ; tests for the function 'isMember'


### PR DESCRIPTION
- The `getGuardSetExp` function is modified to handle literal and (NOT $literal) inputs which returns them back as their guardSet.
- Also, I used 'not' in my previous implementation of the `Not` method, `isConsistentExp` method, and testcases. These are now replaced with 'NOT'