### PR TITLE
implemented the 1-Constraint-Subsumption Transformation

### DIFF
--- a/enf-reducer/one-constraint-subsumption.metta
+++ b/enf-reducer/one-constraint-subsumption.metta
@@ -1,5 +1,6 @@
 ;a function which implements the 1-Constraint-Subsumption Transformation
 (= (oneConstraintSubsume $expOriginal $expRecursive $commandSet) 
+(if (== $expRecursive ()) $expOriginal
 (let* 
   (
     ($head (car-atom $expRecursive))
@@ -10,8 +11,9 @@
     (OR $expOriginal)
     (NOT $expOriginal)
     (AND (oneConstraintSubsume $expOriginal $tail $commandSet)) ;the POA of this transformation is any non-root AND node
-    ($else (if (isMember $head $commandSet) () $expOriginal)) ;if any constraint of the AND node is found inside the commandSet, the node is removed. if not, it is kept.
+    ($else (if (isMember $head $commandSet) () (oneConstraintSubsume $expOriginal $tail $commandSet))) ;if any constraint of the AND node is found inside the commandSet, the node is removed. if not, it is kept.
   )
   )
   )
+)
 )

--- a/enf-reducer/one-constraint-subsumption.metta
+++ b/enf-reducer/one-constraint-subsumption.metta
@@ -1,0 +1,17 @@
+;a function which implements the 1-Constraint-Subsumption Transformation
+(= (oneConstraintSubsume $expOriginal $expRecursive $commandSet) 
+(let* 
+  (
+    ($head (car-atom $expRecursive))
+    ($tail (cdr-atom $expRecursive))
+  )
+  (case $head
+  (
+    (OR $expOriginal)
+    (NOT $expOriginal)
+    (AND (oneConstraintSubsume $expOriginal $tail $commandSet)) ;the POA of this transformation is any non-root AND node
+    ($else (if (isMember $head $commandSet) () $expOriginal)) ;if any constraint of the AND node is found inside the commandSet, the node is removed. if not, it is kept.
+  )
+  )
+  )
+)

--- a/enf-reducer/tests/one-constraint-subsumption-test.metta
+++ b/enf-reducer/tests/one-constraint-subsumption-test.metta
@@ -1,0 +1,20 @@
+! (register-module! ../../../metta-moses-reduction) 
+! (import! &self metta-moses-reduction:utilities:general-helper-functions)
+! (import! &self metta-moses-reduction:enf-reducer:one-constraint-subsumption)
+
+;Test-01:applied on an empty set(not affected)
+ ! (assertEqualToResult (oneConstraintSubsume () () (A B C)) (()))
+;Test-02:applied on a literal(not affected)
+ ! (assertEqualToResult (oneConstraintSubsume A A (A B C)) (A))
+;Test-03:applied on an OR node(not affected)
+ ! (assertEqualToResult (oneConstraintSubsume (OR A B (AND C D)) (OR A B (AND C D)) (A C D)) ((OR A B (AND C D))))
+;Test-04:applied on a NOT expression(not affected)
+ ! (assertEqualToResult (oneConstraintSubsume (NOT A) (NOT A) (A B)) ((NOT A)))
+;Test-05:applied on an AND Node
+;;; empty $commandSet(the Root node or any AND node which is not commanded by any nodes)
+ ! (assertEqualToResult (oneConstraintSubsume (AND A (OR (AND C D) E)) (AND A (OR (AND C D) E)) ()) ((AND A (OR (AND C D) E))))
+;;; an AND node whose constraint is already inside the $commandSet
+ ! (assertEqualToResult (oneConstraintSubsume (AND A B C) (AND A B C) (A D E F)) (()))
+;;; an AND node whose constraint isn't inside the $commandSet 
+ ! (assertEqualToResult (oneConstraintSubsume (AND A B C) (AND A B C) (D E F)) ((AND A B C)))
+

--- a/enf-reducer/tests/one-constraint-subsumption-test.metta
+++ b/enf-reducer/tests/one-constraint-subsumption-test.metta
@@ -1,5 +1,6 @@
 ! (register-module! ../../../metta-moses-reduction) 
 ! (import! &self metta-moses-reduction:utilities:general-helper-functions)
+! (import! &self metta-moses-reduction:enf-reducer:rte-helpers)
 ! (import! &self metta-moses-reduction:enf-reducer:one-constraint-subsumption)
 
 ;Test-01:applied on an empty set(not affected)
@@ -11,10 +12,11 @@
 ;Test-04:applied on a NOT expression(not affected)
  ! (assertEqualToResult (oneConstraintSubsume (NOT A) (NOT A) (A B)) ((NOT A)))
 ;Test-05:applied on an AND Node
+;;; the example given in the Holman paper(the POA)
+ ! (assertEqualToResult (oneConstraintSubsume (AND E D) (AND E D) (D)) (()))
 ;;; empty $commandSet(the Root node or any AND node which is not commanded by any nodes)
- ! (assertEqualToResult (oneConstraintSubsume (AND A (OR (AND C D) E)) (AND A (OR (AND C D) E)) ()) ((AND A (OR (AND C D) E))))
+ ! (assertEqualToResult (oneConstraintSubsume (AND A (OR (AND B (OR (AND E D) C)) D)) (AND A (OR (AND B (OR (AND E D) C)) D)) ()) ((AND A (OR (AND B (OR (AND E D) C)) D))))
 ;;; an AND node whose constraint is already inside the $commandSet
  ! (assertEqualToResult (oneConstraintSubsume (AND A B C) (AND A B C) (A D E F)) (()))
 ;;; an AND node whose constraint isn't inside the $commandSet 
  ! (assertEqualToResult (oneConstraintSubsume (AND A B C) (AND A B C) (D E F)) ((AND A B C)))
-


### PR DESCRIPTION
The POA for this transformation is any non-root `AND` node. If any constraints of the node are already found inside the `$commandSet` the node is removed, if not, it's kept. 
- I have used the `isMember` method from general-helper-functions.