### PR TITLE
Ordered Set Exemplar selection fixed for mettalog

### DIFF
--- a/deme/deme-id-creation.metta
+++ b/deme/deme-id-creation.metta
@@ -4,7 +4,7 @@
 ;; the number of expansion is set to zero (0) in moses_params.h in the moses_statistics struct
 
 ;; for number to string conversion
-! (bind! numStr (py-atom str))
+; ! (bind! numStr (py-atom str)) -- commented out for workflow compatibility
 
 ;; DemeId Type
 (: DemeId Type)
@@ -17,18 +17,16 @@
 (= (createDemeIds $nExpansion $nDeme)
     (if (> $nDeme 1)
         (demeIdList (+ $nExpansion 1) (- $nDeme 1) Nil)
-        (let* (
-                ($str (numStr (+ $nExpansion 1)))
-                ($demeId (mkDemeId $str)))
-
-                (Cons $demeId Nil))))
-
+        (chain (+ $nExpansion 1) $n 
+            (chain (format-args "{}" ($n)) $str 
+                (chain (mkDemeId $str) $demeId (Cons $demeId Nil))))))
+        
 ;; demeIdList -- recursive function for creating list of demeId's 
 (= (demeIdList $nExpansion $nDeme $list)
     (if (< $nDeme 0)
         $list
-        (let* ((($str1 $str2)((numStr $nExpansion) (numStr $nDeme)))
-                ($demeId (mkDemeId (charsToString ($str1 "." $str2))))
+        (let* ((($str1 $str2)( (format-args "{}" ($nExpansion)) (format-args "{}" ($nDeme))))
+                ($demeId (mkDemeId (format-args "{}.{}" ($str1 $str2))))
                 ($newList (List.prepend $demeId $list)))
                 
                 (demeIdList $nExpansion (- $nDeme 1) $newList))))

--- a/deme/tests/deme-id-creation-test.metta
+++ b/deme/tests/deme-id-creation-test.metta
@@ -1,0 +1,8 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:utilities:list-methods)
+! (import! &self metta-moses:deme:deme-id-creation)
+
+;; Test cases -- createDemeIds
+! (assertEqual (createDemeIds 0 1) (Cons (mkDemeId "1") Nil))
+! (assertEqual (createDemeIds 0 2) (Cons (mkDemeId "1.0") (Cons (mkDemeId "1.1") Nil)))
+! (assertEqual (createDemeIds 0 3) (Cons (mkDemeId "1.0") (Cons (mkDemeId "1.1") (Cons (mkDemeId "1.2") Nil))))

--- a/metapopulation/exemplar-selection.metta
+++ b/metapopulation/exemplar-selection.metta
@@ -2,8 +2,9 @@
 ;; random-float and random-int both require what is denoted as RandomGenerator
 ;; which, for now, is not clear what it is
 
-! (bind! rndfloat (py-atom random.random))
-! (bind! round (py-atom round))
+;; removed python binding for compatibility with workflow -- XXX 
+; ! (bind! rndfloat (py-atom random.random))
+; ! (bind! round (py-atom round))
 ! (bind! NO_EXEMPLAR "empty metapopulation")
 ! (bind! COMPXY_TEMP 4)
 ! (bind! INV_TEMP (/ 100.0 COMPXY_TEMP))
@@ -54,7 +55,7 @@
 
 (: rouletteSelect (-> (OS (Exemplar $a)) (List Number) Number (Exemplar $a)))
 (= (rouletteSelect $metaPop $probs $sum)
-    (let* (($rndfloat (rndfloat))
+    (let* (($rndfloat (randomFloat))
            ($ajstdSum (* $sum $rndfloat))
             ($index (roulette $probs 0 $ajstdSum)))
         (OS.getByIdx $index $metaPop)))

--- a/metapopulation/metapopulation.metta
+++ b/metapopulation/metapopulation.metta
@@ -3,9 +3,6 @@
 ; ! (bind! COMP-TEMP 6.0)
 ; ! (bind! CAP-COEF 50)
 
-;; python int casting function
-! (bind! int (py-atom "int"))
-
 ;; Exemplar type
 (: Exemplar (-> $a Type))
 (: mkExemplar (-> (Tree $a) DemeId Cscore BehavioralScore (Exemplar $a)))
@@ -101,4 +98,3 @@
 ;; Return: $tree
 (: getExemplarTree (-> (Exemplar $a) (Tree $a)))
 (= (getExemplarTree (mkExemplar $tree $demeId $cscore $bscore)) $tree)
-

--- a/metapopulation/tests/exemplar-selection-test.metta
+++ b/metapopulation/tests/exemplar-selection-test.metta
@@ -1,0 +1,109 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:utilities:ordered-set)
+! (import! &self metta-moses:utilities:list-methods)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:metapopulation:exemplar-selection)
+! (import! &self metta-moses:metapopulation:metapopulation)
+! (import! &self metta-moses:utilities:tree)
+(: A Bool)
+;; Get penalized scores
+! (assertEqual (getPnScore NilOS) Nil)
+! (assertEqual 
+    (getPnScore 
+        (ConsOS (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.2 1 0.1 0.1 -0.4) (mkBScore (Cons 0 (Cons 0 Nil))))
+        (ConsOS (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil)) (mkDemeId "1") (mkCscore -0.1 2 0.2 0.3 -0.6) (mkBScore (Cons 0 (Cons 0 Nil)))) 
+                 NilOS)))
+    (Cons -0.4 (Cons -0.6 Nil)))
+! (assertEqual 
+    (getPnScore 
+        (ConsOS 
+            (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil)) (mkDemeId "1") (mkCscore -0.1 2 0.2 0.3 -0.6) (mkBScore (Cons 0 (Cons 0 Nil)))) 
+            (ConsOS 
+                (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil)) (mkDemeId "1") (mkCscore -0.1 2 0.2 0.3 -0.6) (mkBScore (Cons 0 (Cons 0 Nil))))
+                        NilOS)))
+    (Cons -0.6 (Cons -0.6 Nil)))
+
+;; max of list of values of (List $a) type
+! (assertEqual (List.max >= Nil) Nil)
+! (assertEqual (List.max >= (Cons 0.75 Nil)) 0.75)
+! (assertEqual (List.max >= (Cons 0.9 (Cons 0.5 Nil))) 0.9)
+! (assertEqual (List.max >= (Cons 0.1 (Cons 0.4 (Cons 0.65 (Cons 0.9 Nil))))) 0.9)
+
+;; Boltzman adjusted probablity values
+! (assertEqual (let $a (List.sum (normalizeProbs INV_TEMP 0.5 (Cons 0.3 Nil))) (get-type $a)) Number)
+! (assertEqual (let $a (List.sum (normalizeProbs INV_TEMP 0.7 (Cons 0.6 (Cons 0.2 Nil)))) (get-type $a)) Number)
+! (assertEqual (let $a (List.sum (normalizeProbs INV_TEMP 0.95 (Cons 0.95 (Cons 0.9 (Cons 0.85 Nil))))) (get-type $a)) Number)
+! (assertEqual (let $a (List.sum (normalizeProbs INV_TEMP 1.0 (Cons 0.9 (Cons 0.85 (Cons 0.95 (Cons 0.7 Nil)))))) (get-type $a)) Number)
+
+;; roulette -- spinning the wheel favoring expressions with higher scores 
+! (assertEqual (roulette (Cons 1.0 Nil) 0 0.57) 0)
+! (assertEqual (roulette (Cons 1.0 (Cons 0.0067 Nil)) 0 0.9564) 0)
+! (assertEqual (roulette (Cons 0.0821 (Cons 0.0067 (Cons 1 Nil))) 0 0.7622) 2)
+! (assertEqual (roulette (Cons 0.2 (Cons 0.5 (Cons 0.6 (Cons 0.2 Nil)))) 0 1.1) 2)
+! (assertEqual (roulette (Cons 0.0067 (Cons 0.0821 (Cons 1.0 Nil))) 0 0.0108) 1)
+
+;; Tree Definitions
+! (bind! treeA (mkTree (mkNode A) Nil))
+! (bind! treeB (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode C) Nil) Nil))))
+! (bind! treeC (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))))
+! (bind! treeY (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode Z) Nil) Nil))))
+! (bind! treeZ (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode X) Nil) Nil))))
+! (bind! tree2 (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) Nil)))
+! (bind! tree3 (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode E) Nil) Nil))))
+
+;; rouletteSelect
+! (bind! exemplar-list0 (ConsOS (mkExemplar treeA (mkDemeId "1") (mkCscore 0.9 0.5 0.2 0.1 -0.6) (mkBscore (Cons 1 (Cons 0 Nil))))
+                        (ConsOS (mkExemplar treeB (mkDemeId "2") (mkCscore 0.85 0.6 0.1 0.05 0.6) (mkBscore (Cons 1 (Cons 0 Nil))))
+                          (ConsOS (mkExemplar treeC (mkDemeId "3") (mkCscore 0.4 0.7 0.05 0.01 0.3) (mkBscore (Cons 1 (Cons 0 Nil))))
+                            NilOS))))
+! (assertEqual 
+  (let $choice (rouletteSelect exemplar-list0
+        (Cons 0.996 (Cons 1.0 (Cons 0.9857 Nil))) 2.9817)
+          (OS.contains exemplar-list0 $choice)) True)
+
+! (bind! exemplar-list1 (ConsOS (mkExemplar treeA (mkDemeId "9") (mkCscore 0.91 0.3 0.25 0.13 0.3) (mkBscore (Cons 1 (Cons 0 Nil)))) 
+                        (ConsOS (mkExemplar treeY (mkDemeId "10") (mkCscore 0.88 0.4 0.22 0.12 0.4) (mkBscore (Cons 1 (Cons 1 Nil)))) 
+                          (ConsOS (mkExemplar treeZ (mkDemeId "11") (mkCscore 0.83 0.5 0.15 0.10 0.5) (mkBscore (Cons 0 (Cons 1 Nil)))) 
+                            NilOS))))
+! (assertEqual 
+  (let $choice (rouletteSelect exemplar-list1 (Cons 0.9753 (Cons 0.9936 (Cons 1.0 Nil))) 2.9689)
+    (OS.contains exemplar-list1 $choice )) True)
+
+! (bind! exemplar-list2 (ConsOS (mkExemplar treeA (mkDemeId "7") (mkCscore 0.95 0.3 0.2 0.1 0.2) (mkBscore (Cons 1 (Cons 1 Nil))))  
+                        (ConsOS (mkExemplar tree2 (mkDemeId "8") (mkCscore 0.80 0.6 0.1 0.05 0.2) (mkBscore (Cons 1 (Cons 1 Nil))))  
+                          (ConsOS (mkExemplar tree3 (mkDemeId "12") (mkCscore 0.5 0.9 0.05 0.03 0.1) (mkBscore (Cons 1 (Cons 0 Nil))))   
+                            NilOS))))
+
+! (assertEqual 
+  (let $choice (rouletteSelect exemplar-list2 (Cons 0.9654 (Cons 1.0 (Cons 0.9057 Nil))) 2.8711)
+  (OS.contains exemplar-list2 $choice)) True)
+
+;; selectExemplar
+! (assertEqual (selectExemplar NilOS) (Error NilOS "empty metapopulation"))
+
+! (bind! treeA-x (mkExemplar treeA (mkDemeId "7") (mkCscore 0.95 0.3 0.2 0.1 0.4) (mkBscore (Cons 1 (Cons 1 Nil)))))
+
+! (assertEqual (selectExemplar (ConsOS treeA-x NilOS)) treeA-x)
+
+! (bind! test1-exemplars
+  (ConsOS (mkExemplar treeA (mkDemeId "1") (mkCscore 0.8 0.3 0.1 0.01 0.4) (mkBscore (Cons 1 (Cons 1 Nil))))  
+    (ConsOS (mkExemplar tree2 (mkDemeId "2") (mkCscore 0.7 0.4 0.05 0.05 0.5) (mkBscore (Cons 0 (Cons 1 Nil)))) 
+      (ConsOS (mkExemplar tree3 (mkDemeId "3") (mkCscore 0.6 0.5 0.0 0.0 0.6) (mkBscore (Cons 1 (Cons 0 Nil))))    
+        NilOS))))
+
+! (assertEqual (let $choice (selectExemplar test1-exemplars) (OS.contains test1-exemplars $choice)) True)
+
+! (bind! test2-exemplars
+  (ConsOS (mkExemplar treeA (mkDemeId "101") (mkCscore 0.9 0.3 0.05 0.02 0.6) 
+          (mkBscore (Cons 1 (Cons 1 (Cons 1 (Cons 1 Nil))))))  
+    (ConsOS (mkExemplar treeB (mkDemeId "102") (mkCscore 0.6 0.5 0.1 0.1 0.5) (mkBscore (Cons 1 (Cons 1 (Cons 1 (Cons 1 Nil))))))  
+      (ConsOS (mkExemplar treeC (mkDemeId "103") (mkCscore 0.4 0.4 0.05 0.1 0.4) (mkBscore (Cons 0 (Cons 0 (Cons 1 (Cons 0 Nil))))))     
+        NilOS))))
+! (assertEqual (let $choice (selectExemplar test2-exemplars) (OS.contains test2-exemplars $choice)) True)
+
+! (bind! metaPop (ConsOS (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.2 1 0.1 0.1 5) (mkBScore (Cons 0 (Cons 0 Nil))))
+                 (ConsOS (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil)) (mkDemeId "1") (mkCscore -0.1 2 0.2 0.3 -0.6) (mkBScore (Cons 0 (Cons 0 Nil)))) 
+                 (ConsOS (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil)) (mkDemeId "1") (mkCscore -0.1 2 0.2 0.3 -0.006) (mkBScore (Cons 0 (Cons 0 Nil)))) NilOS))))
+               
+; ! (assertEqual (let $choice (selectExemplar metaPop) ((get-type $choice) (OS.contains metaPop $choice))) ((Exemplar Bool) True))
+! (assertEqual (let $choice (selectExemplar metaPop) (OS.contains metaPop $choice))  True)

--- a/metapopulation/tests/metapopulation-test.metta
+++ b/metapopulation/tests/metapopulation-test.metta
@@ -1,0 +1,288 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:metapopulation:metapopulation)
+! (import! &self metta-moses:scoring:cscore)
+! (import! &self metta-moses:scoring:fitness)
+! (import! &self metta-moses:scoring:bscore)
+! (import! &self metta-moses:utilities:ordered-set)
+! (import! &self metta-moses:utilities:tree)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:utilities:list-methods)
+! (import! &self metta-moses:deme:deme-id-creation)
+
+;; Test cases for getBetterCandidates
+! (assertEqual (getBetterCandidates (ConsOS 
+      (mkExemplar 
+        (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+        (mkDemeId "1") 
+        (mkCscore -0.1 2 0.1 0.1 -0.3) 
+        (mkBScore (Cons 0.5 Nil))) 
+      NilOS) -0.2) NilOS)
+
+! (assertEqual 
+      (getBetterCandidates 
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+                (mkDemeId "1") 
+                (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                (mkBScore (Cons 0.5 Nil))) 
+              NilOS) 
+        -0.4) 
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.5 Nil))) 
+                NilOS))
+
+! (bind! pop1 (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode XOR) (Cons (mkTree (mkNode X) Nil) (Cons (mkTree (mkNode Y) Nil) Nil))) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.5 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode AND) (Cons (mkTree (mkNode M) Nil) (Cons (mkTree (mkNode N) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      (ConsOS 
+                        (mkExemplar 
+                          (mkTree (mkNode NOT) (Cons (mkTree (mkNode Z) Nil) Nil)) 
+                          (mkDemeId "2") 
+                          (mkCscore -0.5 3 0.1 0.1 -0.9) 
+                          (mkBScore (Cons 0.4 Nil))) 
+                        NilOS))))
+
+! (assertEqual (getBetterCandidates pop1 -0.5) 
+                  (ConsOS 
+                    (mkExemplar 
+                      (mkTree (mkNode XOR) (Cons (mkTree (mkNode X) Nil) (Cons (mkTree (mkNode Y) Nil) Nil))) 
+                      (mkDemeId "1") 
+                      (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                      (mkBScore (Cons 0.5 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode AND) (Cons (mkTree (mkNode M) Nil) (Cons (mkTree (mkNode N) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      NilOS)))
+! (bind! pop2 (ConsOS (mkExemplar 
+                        (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                        (mkDemeId "1") 
+                        (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                        (mkBScore (Cons 0.9 Nil))) 
+                        (ConsOS  (mkExemplar 
+                            (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                            (mkDemeId "2") 
+                            (mkCscore -0.2 3 0.1 0.1 -0.4) 
+                            (mkBScore (Cons 0.8 Nil))) 
+                          (ConsOS (mkExemplar 
+                              (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                              (mkDemeId "3") 
+                              (mkCscore -0.3 1 0.1 0.1 -0.5) 
+                              (mkBScore (Cons 0.7 Nil))) 
+                            (ConsOS (mkExemplar 
+                                (mkTree (mkNode XOR) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+                                (mkDemeId "4") 
+                                (mkCscore -0.5 4 0.1 0.1 -0.7) 
+                                (mkBScore (Cons 0.6 Nil))) 
+                              (ConsOS (mkExemplar 
+                                  (mkTree (mkNode IMPLIES) (Cons (mkTree (mkNode H) Nil) (Cons (mkTree (mkNode I) Nil) Nil))) 
+                                  (mkDemeId "5") 
+                                  (mkCscore -0.6 2 0.1 0.1 -0.8) 
+                                  (mkBScore (Cons 0.5 Nil))) 
+                                (ConsOS (mkExemplar 
+                                    (mkTree (mkNode NAND) (Cons (mkTree (mkNode J) Nil) (Cons (mkTree (mkNode K) Nil) Nil))) 
+                                    (mkDemeId "6") 
+                                    (mkCscore -0.9 3 0.1 0.1 -1.1) 
+                                    (mkBScore (Cons 0.4 Nil))) 
+                                  NilOS)))))))
+! (assertEqual 
+  (getBetterCandidates pop2 -0.75) 
+              (ConsOS 
+                (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.9 Nil))) 
+                (ConsOS (mkExemplar 
+                    (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                    (mkDemeId "2") 
+                    (mkCscore -0.2 3 0.1 0.1 -0.4) 
+                    (mkBScore (Cons 0.8 Nil))) 
+                  (ConsOS (mkExemplar 
+                      (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                      (mkDemeId "3") 
+                      (mkCscore -0.3 1 0.1 0.1 -0.5) 
+                      (mkBScore (Cons 0.7 Nil))) 
+                    (ConsOS (mkExemplar 
+                        (mkTree (mkNode XOR) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+                        (mkDemeId "4") 
+                        (mkCscore -0.5 4 0.1 0.1 -0.7) 
+                        (mkBScore (Cons 0.6 Nil))) 
+                      NilOS)))))
+
+;; Test cases for cullAtRandom
+! (bind! pop3 (ConsOS 
+                  (mkExemplar 
+                    (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                    (mkDemeId "1") 
+                    (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                    (mkBScore (Cons 0.5 Nil))) 
+                  (ConsOS 
+                    (mkExemplar 
+                      (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                      (mkDemeId "2") 
+                      (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                      (mkBScore (Cons 0.4 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode XOR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.3 3 0.1 0.1 -0.5) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      NilOS))))
+! (assertEqual (let $a (cullAtRandom pop3 1 2) (OS.length $a)) 1)
+
+! (bind! pop4 (ConsOS 
+        (mkExemplar 
+          (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+          (mkDemeId "1") 
+          (mkCscore -0.1 2 0.1 0.1 -0.3) 
+          (mkBScore (Cons 0.5 Nil))) 
+        (ConsOS 
+          (mkExemplar 
+            (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+            (mkDemeId "2") 
+            (mkCscore -0.2 1 0.1 0.1 -0.4) 
+            (mkBScore (Cons 0.4 Nil))) 
+          (ConsOS 
+            (mkExemplar 
+              (mkTree (mkNode OR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+              (mkDemeId "3") 
+              (mkCscore -0.3 3 0.1 0.1 -0.5) 
+              (mkBScore (Cons 0.3 Nil))) 
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode NAND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                (mkDemeId "4") 
+                (mkCscore -0.4 2 0.1 0.1 -0.6) 
+                (mkBScore (Cons 0.2 Nil))) 
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode XOR) (Cons (mkTree (mkNode C) Nil) (Cons (mkTree (mkNode D) Nil) Nil))) 
+                  (mkDemeId "5") 
+                  (mkCscore -0.5 1 0.1 0.1 -0.7) 
+                  (mkBScore (Cons 0.1 Nil))) 
+                NilOS)))))) 
+
+! (assertEqual (let $result (cullAtRandom pop4 2 2) (OS.length $result)) 3)  
+
+;; Test cases for resizeMetapop
+! (bind! pop5
+  (ConsOS 
+    (mkExemplar 
+      (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+      (mkDemeId "1") 
+      (mkCscore -0.1 2 0.1 0.1 -0.3) 
+      (mkBScore (Cons 0.5 Nil)))
+
+    (ConsOS 
+      (mkExemplar 
+        (mkTree (mkNode OR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+        (mkDemeId "2") 
+        (mkCscore -0.2 3 0.1 0.1 -0.4) 
+        (mkBScore (Cons 0.9 Nil)))
+
+      (ConsOS 
+        (mkExemplar 
+          (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+          (mkDemeId "3") 
+          (mkCscore -0.3 1 0.1 0.1 -0.5) 
+          (mkBScore (Cons 0.4 Nil)))
+
+        (ConsOS 
+          (mkExemplar 
+            (mkTree (mkNode AND) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+            (mkDemeId "4") 
+            (mkCscore -0.4 2 0.1 0.1 -0.6) 
+            (mkBScore (Cons 0.2 Nil)))
+
+          (ConsOS 
+            (mkExemplar 
+              (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+              (mkDemeId "5") 
+              (mkCscore -0.5 1 0.1 0.1 -0.7) 
+              (mkBScore (Cons 0.1 Nil)))
+
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) Nil))) 
+                (mkDemeId "6") 
+                (mkCscore -0.6 3 0.1 0.1 -0.8) 
+                (mkBScore (Cons 0.8 Nil)))
+
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                  (mkDemeId "7") 
+                  (mkCscore -0.7 2 0.1 0.1 -0.9) 
+                  (mkBScore (Cons 0.7 Nil)))
+
+                (ConsOS 
+                  (mkExemplar 
+                    (mkTree (mkNode NOT) (Cons (mkTree (mkNode F) Nil) Nil)) 
+                    (mkDemeId "8") 
+                    (mkCscore -0.8 1 0.1 0.1 -1.0) 
+                    (mkBScore (Cons 0.6 Nil)))
+                  NilOS)))))))))
+
+! (assertEqual (let $a (resizeMetapop pop5 3 5 3 0.004 1000) (OS.length $a)) 6)
+! (assertEqual (let $a (resizeMetapop pop5 3 5 2 0.003 1000) (OS.length $a)) 4)
+
+; ;; Testcases for compareExemplar
+!(assertEqual
+(compareExemplar 
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.1 2 0.1 0.1 -0.3) (mkBScore (Cons 0 (Cons 0 Nil))))
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.2 3 0.1 0.1 -0.4) (mkBScore (Cons 0 (Cons 0 Nil))))
+)G)
+
+!(assertEqual
+(compareExemplar 
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil))))
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 2 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil))))
+) L)
+
+!(assertEqual
+(compareExemplar 
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil))))
+(mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil))))
+) E)
+
+;; Test cases for getExemplarBScore
+!(assertEqual
+(getExemplarBScore (mkExemplar (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil)))))
+(mkBScore (Cons 0 (Cons 0 Nil))))
+
+!(assertEqual
+(getExemplarBScore (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil)))))
+(mkBScore (Cons 0 (Cons 0 Nil))))
+
+;; Test cases for getExemplarPenScore
+!(assertEqual 
+(getExemplarPenScore (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil)))))
+-0.7)
+
+;; Test cases for getExemplarCscore
+!(assertEqual 
+(getExemplarCscore (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil)))))
+(mkCscore -0.5 3 0.1 0.1 -0.7))
+
+;; Test cases for getExemplarTree
+!(assertEqual 
+(getExemplarTree (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))) (mkDemeId "1") (mkCscore -0.5 3 0.1 0.1 -0.7) (mkBScore (Cons 0 (Cons 0 Nil)))))
+(mkTree (mkNode OR) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode C) Nil) Nil)) (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) Nil)) Nil)))) Nil))))
+

--- a/scoring/test/cscore-test.metta
+++ b/scoring/test/cscore-test.metta
@@ -1,0 +1,46 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:utilities:tree)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:utilities:list-methods)
+
+! (import! &self metta-moses:scoring:fitness)
+! (import! &self metta-moses:scoring:bscore)
+! (import! &self metta-moses:scoring:cscore)
+
+; ;; Test cases for updatePenalizedScore
+! (assertEqual (updatePenalizedScore (mkCscore  0  2  0.3 0.5  (* -1 (pow-math 10 308))) False) (mkCscore  0  2  0.3  0.5 -0.8))
+! (assertEqual (updatePenalizedScore (mkCscore  -1  3  0.2  0.4 (* -1 (pow-math 10 308))) True) (mkCscore  -1  3  0.2  0.4  -0.48))
+! (assertEqual (updatePenalizedScore (mkCscore  0  5  0.1  0.9 (* -1 (pow-math 10 308))) False) (mkCscore  0  5  0.1 0.9 -1.0))
+! (assertEqual (updatePenalizedScore (mkCscore  -3 1 0.7 1.0  (* -1 (pow-math 10 308))) False) (mkCscore  -3 1  0.7 1.0  -4.7))
+
+! (bind! ttable1 (mkITable (Cons (Cons True (Cons False (Cons True Nil)))
+                        (Cons (Cons True (Cons True  (Cons True Nil))) Nil)) 
+                        (Cons A (Cons B (Cons O Nil)))))
+! (bind! ttable2 (mkITable
+                    (Cons (Cons True (Cons True (Cons True Nil)))
+                    (Cons (Cons True (Cons False (Cons False Nil)))
+                    (Cons (Cons False (Cons True (Cons False Nil)))
+                    (Cons (Cons False (Cons False (Cons False Nil))) Nil))))
+                    (Cons A (Cons B (Cons Output Nil)))))
+
+! (assertEqual (getCscore ttable1 (buildTree (AND A B)) 2.0) (mkCscore -1 2 1 0 -2))
+! (assertEqual (getCscore ttable1 (buildTree (OR A B)) 4) (mkCscore 0 2 0.5 0 -0.5))
+! (assertEqual (getCscore ttable2 (buildTree (AND A B)) 2.0) (mkCscore 0 2 1.0 0 -1.0))
+! (assertEqual (getCscore ttable2 (buildTree (OR A B)) 1) (mkCscore -2 2 2.0 0 -4.0))
+
+;; Test cases -- getComplexityCoef
+! (assertEqual (getComplexityCoef 0.0) 0.0)
+! (assertEqual (getComplexityCoef 2.0) 0.5)
+! (assertEqual (getComplexityCoef 4) 0.25)
+
+;; Test cases -- composite score less than comparator
+! (assertEqual (cScore< (mkCscore -0.1 2 0.1 0.1 -0.3) (mkCscore -0.2 3 0.1 0.1 -0.4)) False)
+! (assertEqual (cScore< (mkCscore -0.5 3 0.1 0.1 -0.7) (mkCscore -0.5 2 0.1 0.1 -0.7)) True)
+! (assertEqual (cScore< (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5 3 0.1 0.1 -0.7)) False)
+! (assertEqual (cScore< (mkCscore -0.5 2 0.1 0.1 1.5NaN) (mkCscore -0.5 3 0.1 0.1 -0.7)) True)
+
+;; Test cases -- composite score equality comparator 
+! (assertEqual (cScore== (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5 2 0.1 0.1 -0.7)) True)
+! (assertEqual (cScore== (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5000001 2.0000001 0.1 0.1 -0.7000001)) True)
+! (assertEqual (cScore== (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.6 2 0.1 0.1 -0.8)) False)
+! (assertEqual (cScore== (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5 3 0.1 0.1 -0.7)) False)

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -599,9 +599,10 @@
             (Error ($a or $b) "One of the argument is not a number")))
 
 ;; wrapping the built-in ininf-math with custom function because the return type is not bool, it is number
-;; using the type-cast function
-(: isInf (-> Number Bool))
-(= (isInf $x) (type-cast (isinf-math $x) Bool &self))
+;; using the type-cast function 
+;; obsolete in mettalong for now
+; (: isInf (-> Number Bool))
+; (= (isInf $x) (type-cast (isinf-math $x) Bool &self))
 
 ;; A trick to define composition function.
 ;; Takes a function and returns another function
@@ -702,3 +703,21 @@
 ;; needed because using using the direct python binding appears to cause issue with git workflow
 (: isnan (-> $a Bool))
 (= (isnan $x) (== $x 1.5NaN))
+
+;; isInf -- check if a number if Inf
+;; the same applies to this weid looking 1.0Inf thing - it is what you get when you bind (py-atom "float ('inf')") in mettalog and the followingn function works 
+(: isInf (-> $a Bool))
+(= (isInf $x) (== $x 1.0Inf))
+
+;; int -- replicates pythons int functionality -- convert floating point numbers into integer
+;; uses -- metta's floor-math function
+(: int (-> Number Number))
+(= (int $x) (if (>= $x 0) (floor-math $x) (+ 1 (floor-math $x))))
+
+! (bind! EXP 2.71828)
+
+;; random float  -- fake rnd number [0 1)
+! (bind! maxInt (pow-math 2 64)) ;; pseudo max integer not really the max integer that can be represented 
+;; the idea is to divide a random int taken from 0 upto this number by this number
+(: randomFloat (-> Number))
+(= (randomFloat) (let $rndInt (random-int &rng 0 maxInt) (/ $rndInt maxInt)))

--- a/utilities/ordered-set.metta
+++ b/utilities/ordered-set.metta
@@ -23,9 +23,6 @@
 (= (OS.length NilOS) 0)
 (= (OS.length (ConsOS $x $xs)) (+ 1 (OS.length $xs)))
 
-;; Get by index
-! (bind! INDEX_ERROR "empty set/index out of range")
-
 ;; OS.getByIndx -- get by index
 (: OS.getByIdx (-> Number (OS $a) $a)) 
 (= (OS.getByIdx $idx NilOS) (Error $idx INDEX_ERROR))
@@ -52,13 +49,14 @@
         True
         (OS.contains $xs $el)))
 
-;; removeByIdx
-(OS.removeByIdx (-> (OS $a) Number (OS $a)))
-(= (OS.removeByIdx NilOS $index) (Error NilOS INDEX_ERROR))
+;; OS.removeByIdx 
+(: OS.removeByIdx (-> (OS $a) Number (OS $a)))
+(= (OS.removeByIdx NilOS $index) (Error "empty set/index out of range"))
 (= (OS.removeByIdx (ConsOS $x $xs) $index)
     (if (== $index 0)
         $xs
-        (ConsOS $x (OS.removeByIdx $xs (- $index 1)))))
+        (chain (OS.removeByIdx $xs (- $index 1)) $res
+            (if-error $res $res (ConsOS $x $res)))))
 
 ;; Check if an Exemplar is a member of an ordered set
 ;; Params:
@@ -72,16 +70,16 @@
    (if (== $exemplar $x)
        True
        (OS.isMember $exemplar $xs)))
-
+  
 ; Retrieves the first N elements from an ordered set.
 ; Params:
 ;   $n: Number of elements to return.
 ;   $os: Ordered set of exemplars.
 ; Return: Ordered set containing the first N elements, or all elements if N exceeds the set size.
 (: OS.getTopN (-> Number (OS (Exemplar $a)) (OS (Exemplar $a)))) 
-(= (OS.getTopN $n NilOS) NilOS) 
-(= (OS.getTopN 0 $os) NilOS) 
-(= (OS.getTopN $n (ConsOS $x $xs)) 
-   (if (<= $n 1) 
-       (ConsOS $x NilOS) 
-       (ConsOS $x (OS.getTopN (- $n 1) $xs))))
+(= (OS.getTopN $n NilOS) (Error NilOS "empty ordered set/ fewer items than required")) 
+(= (OS.getTopN $n (ConsOS $x $xs))
+    (if (== $n 1)
+        (ConsOS $x NilOS)
+        (chain (OS.getTopN (- $n 1) $xs) $res 
+            (if-error $res $res (ConsOS $x $res)))))

--- a/utilities/tests/ordered-set-test.metta
+++ b/utilities/tests/ordered-set-test.metta
@@ -1,0 +1,126 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:utilities:ordered-set)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:metapopulation:exemplar-type)
+
+;; Length of an ordered set
+! (assertEqual (OS.length NilOS) 0)
+! (assertEqual (OS.length (ConsOS 1 NilOS)) 1)
+! (assertEqual (OS.length (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS))))) 4)
+
+;; Get element by index
+! (assertEqual (OS.getByIdx 0 NilOS) (Error 0 "empty set/index out of range"))
+! (assertEqual (OS.getByIdx 3 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))) (Error 0 "empty set/index out of range"))
+! (assertEqual (OS.getByIdx 0 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))) 3)
+! (assertEqual (OS.getByIdx 1 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))) 2)
+! (assertEqual (OS.getByIdx 2 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))) 1)
+
+;; Insert numerals into an ordered set 
+! (assertEqual (OS.insert compareNum 3 (ConsOS 2 (ConsOS 1 NilOS))) (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS))))
+! (assertEqual (OS.insert compareNum 3 (ConsOS 5 (ConsOS 1 NilOS))) (ConsOS 5 (ConsOS 3 (ConsOS 1 NilOS))))
+! (assertEqual (OS.insert compareNum -1 (ConsOS 5 (ConsOS 1 NilOS))) (ConsOS 5 (ConsOS 1 (ConsOS -1 NilOS))))
+
+;; Exemplar comparisonstring-to-number 
+! (assertEqual 
+    (compareXmplr 
+        (mkXmplr (mkTree (mkNode A) Nil) (mkDemeId 5) (mkCscore (mkScoreT 0.9) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))
+        (mkXmplr (mkTree (mkNode B) Nil) (mkDemeId 6) (mkCscore (mkScoreT 0.3) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))) 
+        G)
+! (assertEqual 
+    (compareXmplr 
+        (mkXmplr (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) Nil)) (mkDemeId 6) (mkCscore (mkScoreT 0.4) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))
+        (mkXmplr (mkTree (mkNode (NOT B)) Nil) (mkDemeId 5) (mkCscore (mkScoreT 0.4) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))) 
+        E)
+! (assertEqual 
+    (compareXmplr 
+        (mkXmplr (mkTree (mkNode C) Nil) (mkDemeId 3) (mkCscore (mkScoreT 0.3) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))
+        (mkXmplr (mkTree (mkNode (NOT D)) Nil) (mkDemeId 4) (mkCscore (mkScoreT 0.4) (mkComplexity 0.42) (mkScoreT 0.85) (mkScoreT 0.63)) (mkBscore NilNum))) L)
+                
+;; Insert exemplars into an oreded set
+! (assertEqual 
+    (OS.insert compareXmplr (mkXmplr (mkTree treeA) (mkDemeId 5) (mkCscore (mkScoreT 0.5) (mkComplexity 0.35) (mkScoreT 0.78) (mkScoreT 0.69)) (mkBscore (Cons 1 (Cons 0 NilNum)))) NilOS)
+    (ConsOS (mkXmplr (mkTree treeA) (mkDemeId 5) (mkCscore (mkScoreT 0.5) (mkComplexity 0.35) (mkScoreT 0.78) (mkScoreT 0.69)) (mkBscore (Cons 1 (Cons 0 NilNum)))) NilOS))  
+
+! (assertEqual 
+    (OS.insert compareXmplr (mkXmplr (mkTree treeX) (mkDemeId 10) 
+        (mkCscore (mkScoreT 0.6) (mkComplexity 0.4) (mkScoreT 0.2) (mkScoreT 0.1)) 
+        (mkBscore (Cons 3 (Cons 2 NilNum)))) NilOS)
+
+    (ConsOS (mkXmplr (mkTree treeX) (mkDemeId 10) 
+        (mkCscore (mkScoreT 0.6) (mkComplexity 0.4) (mkScoreT 0.2) (mkScoreT 0.1)) 
+        (mkBscore (Cons 3 (Cons 2 NilNum)))) NilOS))
+
+! (assertEqual (OS.insert compareXmplr (mkXmplr (mkTree treeC) (mkDemeId 7) (mkCscore (mkScoreT 0.6) (mkComplexity 0.30) (mkScoreT 0.70) (mkScoreT 0.55)) (mkBscore 1.30))  
+   (ConsOS (mkXmplr (mkTree treeA) (mkDemeId 5) (mkCscore (mkScoreT 0.5) (mkComplexity 0.35) (mkScoreT 0.78) (mkScoreT 0.69)) (mkBscore (Cons 1 (Cons 0 NilNum))))
+        (ConsOS (mkXmplr (mkTree treeB) (mkDemeId 6) (mkCscore (mkScoreT 0.2) (mkComplexity 0.55) (mkScoreT 0.90) (mkScoreT 0.72)) (mkBscore 1.25))  
+            NilOS))) 
+    (ConsOS (mkXmplr (mkTree treeC) (mkDemeId 7) (mkCscore (mkScoreT 0.6) (mkComplexity 0.30) (mkScoreT 0.70) (mkScoreT 0.55)) (mkBscore 1.30)) 
+        (ConsOS (mkXmplr (mkTree treeA) (mkDemeId 5) (mkCscore (mkScoreT 0.5) (mkComplexity 0.35) (mkScoreT 0.78) (mkScoreT 0.69)) (mkBscore (Cons 1 (Cons 0 NilNum))))
+        (ConsOS (mkXmplr (mkTree treeB) (mkDemeId 6) (mkCscore (mkScoreT 0.2) (mkComplexity 0.55) (mkScoreT 0.90) (mkScoreT 0.72)) (mkBscore 1.25))  
+            NilOS))))
+(assertEqual 
+    (OS.insert compareXmplr 
+        (mkXmplr (mkTree treeB) (mkDemeId 15) 
+            (mkCscore (mkScoreT 0.6) (mkComplexity 0.35) (mkScoreT 0.2) (mkScoreT 0.1)) 
+            (mkBscore (Cons 1 NilNum)))
+        
+        (ConsOS (mkXmplr (mkTree treeA) (mkDemeId 5) 
+            (mkCscore (mkScoreT 0.8) (mkComplexity 0.3) (mkScoreT 0.2) (mkScoreT 0.1)) 
+            (mkBscore (Cons 3 NilNum)))
+
+        (ConsOS (mkXmplr (mkTree treeC) (mkDemeId 25) 
+            (mkCscore (mkScoreT 0.6) (mkComplexity 0.4) (mkScoreT 0.2) (mkScoreT 0.1)) 
+            (mkBscore (Cons 2 NilNum))) NilOS)))
+        
+    (ConsOS (mkXmplr (mkTree treeA) (mkDemeId 5) 
+        (mkCscore (mkScoreT 0.8) (mkComplexity 0.3) (mkScoreT 0.2) (mkScoreT 0.1)) 
+        (mkBscore (Cons 3 NilNum)))
+
+    (ConsOS (mkXmplr (mkTree treeB) (mkDemeId 15) 
+        (mkCscore (mkScoreT 0.6) (mkComplexity 0.35) (mkScoreT 0.2) (mkScoreT 0.1)) 
+        (mkBscore (Cons 1 NilNum)))
+
+    (ConsOS (mkXmplr (mkTree treeC) (mkDemeId 25) 
+        (mkCscore (mkScoreT 0.6) (mkComplexity 0.4) (mkScoreT 0.2) (mkScoreT 0.1)) 
+        (mkBscore (Cons 2 NilNum))) NilOS))))
+
+
+;; Take N exemplars from the metapopulation
+! (assertEqual (OS.takeN 0 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) NilOS)
+! (assertEqual (OS.takeN 1 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 NilOS))
+! (assertEqual (OS.takeN 2 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 NilOS)))
+! (assertEqual (OS.takeN 3 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 NilOS))))
+! (assertEqual (OS.takeN 4 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))))
+! (assertEqual (OS.takeN 5 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS))))))
+! (assertEqual (OS.takeN 6 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS))))))
+
+;; Test cases -- Remove by index
+! (assertEqual (OS.removeByIdx (ConsOS 10 (ConsOS 20 NilOS)) 0) (ConsOS 20 NilOS))        
+! (assertEqual (OS.removeByIdx (ConsOS a (ConsOS b (ConsOS c NilOS))) 1) (ConsOS a (ConsOS c NilOS)))
+! (assertEqual (OS.removeByIdx (ConsOS 5 (ConsOS 6 (ConsOS 7 NilOS))) 2) (ConsOS 5 (ConsOS 6 NilOS)))
+! (assertEqual (OS.removeByIdx (ConsOS 1 (ConsOS 2 NilOS)) 5) (Error NilOS "empty set/index out of range"))
+
+;; Test cases -- getTopN
+!(assertEqual
+   (OS.getTopN 2
+         (ConsOS
+            (mkExemplar (mkTree (mkNode A) Nil) (mkDemeId "1") (mkCscore -0.1 2 0.1 0.1 -0.3) (mkBScore (Cons 0 Nil)))
+            (ConsOS
+               (mkExemplar (mkTree (mkNode B) Nil) (mkDemeId "1") (mkCscore -0.2 3 0.1 0.1 -0.4) (mkBScore (Cons 0 Nil)))
+               (ConsOS
+                  (mkExemplar (mkTree (mkNode C) Nil) (mkDemeId "1") (mkCscore -0.3 4 0.1 0.1 -0.5) (mkBScore (Cons 0 Nil)))
+                  NilOS))))
+      (ConsOS
+         (mkExemplar (mkTree (mkNode A) Nil) (mkDemeId "1") (mkCscore -0.1 2 0.1 0.1 -0.3) (mkBScore (Cons 0 Nil)))
+         (ConsOS
+            (mkExemplar (mkTree (mkNode B) Nil) (mkDemeId "1") (mkCscore -0.2 3 0.1 0.1 -0.4) (mkBScore (Cons 0 Nil)))
+            NilOS)))
+
+!(assertEqual
+   (OS.getTopN 5
+         (ConsOS
+            (mkExemplar (mkTree (mkNode A) Nil) (mkDemeId "1") (mkCscore -0.1 2 0.1 0.1 -0.3) (mkBScore (Cons 0 Nil)))
+            (ConsOS
+               (mkExemplar (mkTree (mkNode B) Nil) (mkDemeId "1") (mkCscore -0.2 3 0.1 0.1 -0.4) (mkBScore (Cons 0 Nil)))
+               NilOS)))
+        (Error NilOS "empty ordered set/ fewer items than required"))


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactored `exemplar selection`, `ordered set`, `deme id creation`.
## Motivation and Context
Part of the ongoing effort to refactor the exisiting moses `MeTTa` implementation into `mettalog`.

## How Has This Been Tested?
Locally and git workflow.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
