### PR TITLE
Fix getCScore else evaluation and prevent unintended atom-space update and empty return

### DIFF
--- a/deme/tests/score-deme-test.metta
+++ b/deme/tests/score-deme-test.metta
@@ -123,13 +123,13 @@
 
 ; The these test cases are commented out because they behave non deterministically when running all the 3 representation together 
 ;; but runs correctly when running them separately !!
-; !(assertEqual
-;    (transform
-;    (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 2 Nil)))) -1.0000000000000001e308)) (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 1 Nil)))) -1.0000000000000001e308)) Nil)))
-;    (mkRep (knobMapObj) (tree1))
-;    (ttable2)
-;    1)
-;    (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 1 Nil)))) (mkCscore 0 3 3.0 0.0 -3.0))) (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 2 Nil)))) (mkCscore -4 0 0.0 0.0 -4.0))) Nil)))) True)
+!(assertEqual
+   (transform
+   (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 2 Nil)))) -1.0000000000000001e308)) (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 1 Nil)))) -1.0000000000000001e308)) Nil)))
+   (mkRep (knobMapObj) (tree1))
+   (ttable2)
+   1)
+   (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 1 Nil)))) (mkCscore 0 3 3.0 0.0 -3.0))) (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 (Cons 2 Nil)))) (mkCscore -4 0 0.0 0.0 -4.0))) Nil)))) 
 
 ; ; ;; Testcase for the bitsToIndices
 !(assertEqual (bitsToIndices (Cons 1 (Cons 0 (Cons 1 (Cons 0 Nil)))) 0 ()) (0 2))

--- a/optimization/univariate/test/univariate-test.metta
+++ b/optimization/univariate/test/univariate-test.metta
@@ -72,9 +72,9 @@
 ;; executed recursively multiple times.
 ;; Therefore, until the transform function is fixed, this test case remains commented out.
   
-; !(assertEqual
-;     (let (mkDeme $rep (mkSInstSet $instSet) $id) 
-;          (eval (univariate (deme) (table1) 2.0 1 0.5 0.5 (mkCscore -0.1 2 0.1 0.1 3)))          
-;          (== (eval (List.length $instSet)) 7)) True)
+!(assertEqual
+    (let (mkDeme $rep (mkSInstSet $instSet) $id) 
+         (eval (univariate (deme) (table1) 2.0 1 0.5 0.5 (mkCscore -0.1 2 0.1 0.1 3)))          
+         (== (eval (List.length $instSet)) 7)) True)
 
 

--- a/scoring/cscore.metta
+++ b/scoring/cscore.metta
@@ -4,24 +4,29 @@
 
 ;; (:getCscore (-> (ITable $a) (Tree $a) Number Cscore))
 (= (getCscore $itable $tree $complexityRatio $scoreSpace)
-    (eval (unify $scoreSpace 
+    (chain (collapse (match $scoreSpace 
             ($tree $score) 
-            (trace! "USED from cache XXXXXXXXXXXXXXXXXXXXXXXXXXX " $score)
-            (chain (scoreTree $itable $tree) $bs 
-                (if-error $bs ;; return worst possible composite score
+            (let ($result) $score $result);; If matched score will be ((score)) need to remove ()
+            )
+    ) $val (if (== $val ()) 
+                (chain (eval (scoreTree $itable $tree)) $bs 
+                (eval (if-error $bs ;; return worst possible composite score
                 (worstCscore)
                 (let* (($bsum (eval (sumBScore $bs)))
                     ($_ (println! (Score: $bsum)))
                     ($_ (println! ""))
-                    ($cpxy (treeComplexity $tree))
+                    ($cpxy (eval (treeComplexity $tree)))
                     ($_ (println! (Complexity: $cpxy)))
-                    ($cCoef (getComplexityCoef $complexityRatio))
-                    ($res (updatePenalizedScore (mkCscore $bsum $cpxy (* $cpxy $cCoef) 0.0 (* -1 (pow-math 10 308)))  False))
+                    ($cCoef (eval (getComplexityCoef $complexityRatio)))
+                    ($res (eval (updatePenalizedScore (mkCscore $bsum $cpxy (* $cpxy $cCoef) 0.0 (* -1 (pow-math 10 308)))  False)))
+                    ($_ (println! (updatePenalizedScore: $res)))
                     ($_ (add-atom $scoreSpace ($tree $res)))
                     )
 
-                    $res ))))))
-
+                    $res )))) 
+                $val
+            ) )
+)
 
 ;; getComplexityCoef -- calcualtes the complexity coeffient of a tree   
 ;; takes complexity ratio as input and returns complexity coefficient


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Petta, function arguments are evaluated during parameter assignment at call time. As a result, even when a parameter is not used in the function body, its value is still executed simply because it appears in the function definition. 
This issue affects the **getCScore** function, which calls unify from **utilities/general-helpers.metta**. 
The expected behavior is:
- If the pattern does not exist in the atom-space, compute the score up to updatePenalizedScore and then add the pattern to the space.
- If the pattern already exists, simply return the stored score without recomputation.

However, because the values passed to unify eagerly evaluate both the then and else alternatives, the else branch is executed regardless of whether the pattern exists in the atom-space. This execution happens in the function definition stage rather than in the function body, leading to multiple unintended results being added to the atom-space.

This behavior causes issues when getCScore is executed more than once in a single run.

Additionally, unify was returning Empty when the pattern did not exist, even after executing the else branch. This caused downstream functions (directly or indirectly dependent on getCScore) to halt or fail when attempting to use the returned value.

## Motivation and Context
While testing the univariate optimization on PR #391 , the last test case exhibited an issue where execution entered an endless loop. Although the test output repeatedly reported true, the evaluation continued indefinitely.

Further analysis revealed that the root cause was related to the getCScore function. When getCScore is called two or more times within a single execution, the issue becomes reproducible. This behavior was also observed in the score-deme test case, where getCScore is invoked multiple times.

The problem stems from unintended memory updates caused by eager evaluation, as well as Empty return values that interrupt control flow. These issues lead to **repeated evaluations**, **unnecessary memory growth**, and **execution halts** in dependent logic. Addressing time and memory optimization, preventing invalid Empty returns, and ensuring stable execution when calling getCScore and evaluating its values are essential for correct termination and reliable behavior of functions that depend on it.

## How Has This Been Tested?
- Verified that all getCScore test cases pass consistently across multiple executions.
- Confirmed that all univariate optimization test cases pass repeatedly without delays or the indefinite execution behavior observed previously.
- Verified that all score-deme test cases pass consistently across repeated runs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
