### PR TITLE
fix: fixed an issue related to the expand deme method

### DIFF
--- a/deme/expand-deme.metta
+++ b/deme/expand-deme.metta
@@ -25,12 +25,11 @@
 ;;   $capCoef: Capacity coefficient for resizing.
 ;;   $genCount: Generation count for resizing.
 ;; Returns:
-;;   $updatedMetaPop: Updated metapopulation with the new optimized deme merged in.
+   ;;   $updatedMetaPop: Updated metapopulation with the new optimized deme merged in.
 ; (: expandDeme (-> (OS (Exemplar $a)) Number Number Bool Symbol (TruthTableBScore $a) (-> Deme (TruthTableBScore $a) Instance $Scorer (Instance Deme $state)) $Scorer Number Number Number Number (ITable $a) Number Number Number (OS (Exemplar $a))))
 (= (expandDeme $metaPop $nExpansion $nDeme $prune-exemplar $fs-algo $truthTableBScore $optimize $itable $scorerType)
-(collapse
-  (let*
-(
+(let*
+   (
     ($exemplar (trace! "Selecting Exemplar" (eval (selectExemplar $metaPop))))
     ($_ (println! $exemplar))
     ($tree (trace! "getting exemplar tree" (eval (getExemplarTree $exemplar)))) 
@@ -38,15 +37,22 @@
     ($demeIds (trace! "creating deme IDs" (eval (createDemeIds $nExpansion $nDeme))))
     ($_ (println! $demeIds))
     ; ($argLabels (getArgLabels $itable))
-    ($demes (trace! "Creating Deme" (eval (createDeme $nDeme $demeIds $tree $itable $fs-algo $prune-exemplar () $scorerType))))      
-    ((mkDeme (mkRep (mkKbMap (mkDscKbMp $dscKbMp) (mkDscMp $dscMp)) $updatedTree) $sInstList $demeId) (superpose $demes))
+    ($demes (trace! "Creating Deme" (eval (createDeme $nDeme $demeIds $tree $itable $fs-algo $prune-exemplar () $scorerType))))     
+    )
+    (map-atom $demes $deme (expandDemeHelper $deme $truthTableBScore $optimize))
+   ))
+
+(= (expandDemeHelper (mkDeme (mkRep (mkKbMap (mkDscKbMp $dscKbMp) (mkDscMp $dscMp)) $updatedTree) $sInstList $demeId) $truthTableBScore $optimize)
+(let*
+(
     ($lengthOfDscKbMp (eval (Map.length $dscKbMp)))
     ($generatedList (eval (List.generate $lengthOfDscKbMp 0)))
     ($deme (mkDeme (mkRep (mkKbMap (mkDscKbMp $dscKbMp) (mkDscMp $dscMp)) $updatedTree) $sInstList $demeId))
-    (($inst $optimDeme $state) (trace! "Optimizing Deme" (eval (optimizeDemes $deme $truthTableBScore (mkInst $generatedList) $optimize)))) ;; the hillclimbing is called under this and it calls the neighborhood and stuff to first populate the deme with instances
+    (($inst $optimDeme $state) (trace! "Optimizing Deme" (eval (optimizeDemes $deme $truthTableBScore (mkInst $generatedList) $optimize))))
 )
-$optimDeme)))
-
+$optimDeme
+)
+)
 ;; The main loop 
 ;; Takes 2 termination criterias:
 ;;     - $maxGen : how many times we want the loop to run
@@ -70,7 +76,9 @@ $optimDeme)))
        ($_ (println! (Top Exemplar before expansion: $top)))
        ($topScore (eval (getExemplarCscore $top)))
        ($_ (println! (topscore: $topScore)))
-       ($resultCandi (if (<= $maxCandOutput (eval (OS.length $metaPop))) (eval (OS.getTopN $maxCandOutput $metaPop)) $metaPop)))
+       ($resultCandi (if (<= $maxCandOutput (eval (OS.length $metaPop))) (eval (OS.getTopN $maxCandOutput $metaPop)) $metaPop))
+       ($_ (cut))
+      )
  (if (eval (cScore>= $topScore $maxScore))
          $resultCandi 
          (eval (runMoses (- $maxGen 1) $maxScore $maxCandOutput $updatedMetaPop $nExpansion $nDeme $prune-exemplar $fs-algo $truthTableBScore $optimize $nEval $maxCandsPerDeme $minPoolSize $complexityTemperature $itable $nToKeep $capCoef $genCount))))))


### PR DESCRIPTION
## Description
When testing the main loop with larger data, it used to be stuck inside the expand deme function immediately after it's done optimizing. Found out it was because of Collapse and I have now updated it to use map-atom. Now, it's working fine even with much larger data.  

## Motivation and Context
This will contribute to further test our system and to use it in our next steps.

## How Has This Been Tested?
It has been tested inside peTTa environment. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
