### PR TITLE
feat: add crossTopTwo and crossTopThree multi-parent crossover operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A short example, from beginning to end, can be found in this Jupyter notebook (c
 There is also a considerable amount of information in the OpenCog wiki: http://wiki.opencog.org/w/Meta-Optimizing_Semantic_Evolutionary_Search
 
 ## Running the code
-- Make sure to install MeTTaLog `SWI-Prolog version 9.3.25` following the instruction on the [metta-wam](https://github.com/trueagi-io/metta-wam?tab=readme-ov-file#windows-installation) repository.
-- The entry point to our algorithm is found in [this file](https://github.com/iCog-Labs-Dev/metta-moses/blob/main/deme/tests/expand-demes-test.metta). There are test cases in an assert equal, but there are also additional running examples you can use which are commented out for now. You can use the following command to run the tests using `mettalog` after successfully installing mettalog on your machine.
+- Make sure to install PeTTa following the instruction on the [PeTTa](https://github.com/trueagi-io/PeTTa) repository.
+- The entry point to our algorithm is found in [this file](https://github.com/iCog-Labs-Dev/metta-moses/blob/main/deme/tests/expand-demes-test.metta). There are test cases in an assert equal, but there are also additional running examples you can use which are commented out for now. You can use the following command to run the tests using `PeTTa` after successfully installing mettalog on your machine.
     ```sh
-       mettalog deme/tests/expand-demes-test.metta
+      ./PeTTa/run.sh deme/tests/expand-demes-test.metta
     ```
 ## Contributing
 Before you start contributing to this repository, make sure to read the [CONTRIBUTING.md](https://github.com/iCog-Labs-Dev/metta-moses/tree/main/.github/CONTRIBUTING.md) file from our repository. 

--- a/optimization/hillclimbing/cross-top-three-helpers.metta
+++ b/optimization/hillclimbing/cross-top-three-helpers.metta
@@ -1,0 +1,67 @@
+;; Cube root approximation using power function
+;; Used to estimate sorting size for 3-simplex selection
+(= (cbrt-math $n)
+   (pow-math $n (/ 1 3)))
+
+;; Extracts raw instance from scored instance wrapper (mkSInst)
+;; Used before applying merge operations
+(= (getInst (mkSInst (mkPair $inst $score)))
+  (match &self (mkSInst (mkPair $inst $score) $inst)))
+
+
+;; Merges three instances into one using sequential application:
+;; k -> iRef -> jRef using mergeInstance
+;; Produces a new scored instance with worst score placeholder
+(= (mergeTriple $kInst $base $iRef $jRef)
+   (let* (
+        ($temp (mergeInstance $kInst $base $iRef))
+        ($final  (mergeInstance $temp $base $jRef))
+          )
+      (mkSInst (mkPair $final (worstCscore)))
+))
+
+
+;; crossInnerLoop
+;; Combines k-candidates with fixed iRef and jRef
+(= (crossInnerLoop Nil $jRef $iRef $base $acc $limit) $acc)
+
+(= (crossInnerLoop (Cons $k $kRest) $jRef $iRef $base $acc $limit)
+   (if (>= (List.length $acc) $limit)
+        $acc
+       (let $newAcc (mergeTriple (getInst $k) $base $iRef $jRef)
+            (crossInnerLoop $kRest $jRef $iRef $base (Cons $newAcc $acc) $limit))
+       )
+)
+
+
+;; crossMiddleLoop
+;; Iterates over j candidates and triggers inner k-loop
+;; Builds pairwise structure for fixed iRef
+(= (crossMiddleLoop Nil $iRef $kList $base $acc $limit) $acc)
+
+(= (crossMiddleLoop (Cons $j $jRest) $iRef $kList $base $acc $limit)
+   (if (>= (List.length $acc) $limit)
+       $acc
+       (let $newAcc (crossInnerLoop $kList (getInst $j) $iRef $base $acc $limit)
+              (crossMiddleLoop $jRest $iRef $kList $base $newAcc $limit))
+))
+
+
+;; crossOuterLoop wraper
+(= (crossOuterLoop $list $base $limit)
+   (crossOuterLoop-iter $list $list $base Nil $limit)
+)
+
+
+
+;; Iterates over i candidates and manages j/k generation
+;; Maintains prefix list for simplex combinationsr
+(= (crossOuterLoop-iter (Cons $i $iRest) $prefix $base $acc $limit)
+   (if (>= (List.length $acc) $limit)
+       $acc
+       (let $newAcc (crossMiddleLoop $iRest (getInst $i)  $prefix $base $acc $limit)
+            (crossOuterLoop-iter $iRest (Cons $i $prefix) $base $newAcc $limit))
+       )
+   )
+
+

--- a/optimization/hillclimbing/cross-top-three.metta
+++ b/optimization/hillclimbing/cross-top-three.metta
@@ -1,0 +1,33 @@
+
+;; Performs 3-simplex crossover on a sorted subset of a deme.
+;; Generates new instances by combining triples (i, j, k)
+;; where i > j > k, using hierarchical merging.
+
+;; (: crossTopThree (-> Deme Number Number Number Instance Deme))
+(= (crossTopThree $deme $nToMake $sampleStart $sampleSize $baseInstance)
+   (let* (
+        ;; Extract representation, instance set, and ID from deme
+       ((mkDeme (mkRep (mkKbMap $dscKbMp (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId) $deme)
+        
+        ;; Ensure number of generated instances does not exceed  the budget
+        ($max (/ (* $sampleSize (* (- $sampleSize 1) (- $sampleSize 2))) 6))
+        ($limit (if (< $max $nToMake) $max $nToMake))
+        (($prevInst $newInst) (List.splitAt $sampleStart $instSet))
+
+        ($nToSort (+ (cbrt-math (* 6 $limit)) 3))
+
+        ;; Select and partially sort top-scoring instances for crossover
+        ($sorted (List.partialSort instance> $newInst $nToSort Nil))
+   )
+   (if (== $sorted Nil)
+       $deme
+       (let* (
+            ($instList (List.takeN $nToSort $sorted))
+            ($newInstances (crossOuterLoop $instList $baseInstance $limit))
+            )
+            (mkDeme 
+                (mkRep (mkKbMap $dscKbMp (mkDscMp $dscMp)) $tree)
+                (mkSInstSet (List.appendList (exprToList $newInstances) $instSet))
+                 $demeId)
+       
+       ))))

--- a/optimization/hillclimbing/cross-top-two-helpers.metta
+++ b/optimization/hillclimbing/cross-top-two-helpers.metta
@@ -1,0 +1,42 @@
+
+;; Merge two instances using a base instance 
+(= (mergeTargetToRef $target $base $reference )
+   (mergeInstance $target $base $reference))
+   
+
+
+;; Generate newinstances by crossing a fixed reference instance with a list of targets
+(= (crossPairsToRef Nil $reference $base $acc $limit) $acc)
+
+(= (crossPairsToRef (Cons $target $rest) $reference $base $acc $limit)
+   (if (>= (List.length $acc) $limit)
+       $acc
+       (let $merged (mergeTargetToRef  (getInst $target) $base $reference)
+                (crossPairsToRef $rest $reference $base (Cons (mkSInst (mkPair $merged (worstCscore))) $acc) $limit))
+))
+
+
+;; Iterate over all reference instances to build full pairwise crossover set
+(= (crossPairs $list $base $limit)
+   (crossPairsIter $list $base Nil $limit))
+
+
+;; Recursive accumulator loop for pairwise crossover generation
+(= (crossPairsIter Nil $base $acc $limit) $acc)
+
+(= (crossPairsIter (Cons $reference $rest) $base $acc $limit)
+   (if (>= (List.length $acc) $limit)
+       $acc
+       (let $newAcc (crossPairsToRef $rest (getInst $reference) $base $acc $limit)
+            (crossPairsIter $rest $base $newAcc $limit))
+))
+
+
+
+
+
+
+
+
+
+

--- a/optimization/hillclimbing/cross-top-two.metta
+++ b/optimization/hillclimbing/cross-top-two.metta
@@ -1,0 +1,47 @@
+; ;; crossTopTwo -- Cross pairs of high-scoring instances in a 2-simplex pattern.
+
+;;       Generates new instances by pairwise crossover of top-ranked instances - 2-simplex
+;;       Each pair (j < i) is merged using a base instance to create new instance.
+
+
+;; (: crossTopTwo (-> Deme Number Number Number Instance Deme))
+(= (crossTopTwo $deme $nToMake $sampleStart $sampleSize $baseInstance)
+   (let* (
+
+        ;; Extract representation, instance set, and ID from deme
+        ((mkDeme (mkRep (mkKbMap $dscKbMp (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId) $deme)
+         (($prevInst $newInst) (List.splitAt $sampleStart $instSet))
+
+        ;; Ensure number of generated instances does not exceed possible pair combinations
+        ($maxPairs (/ (* $sampleSize (- $sampleSize 1)) 2))
+        ($nToMakeNew (if (< $maxPairs $nToMake) $maxPairs $nToMake))
+
+        ($nToSort  (+ (sqrt-math (* 2 $nToMakeNew)) 3))
+
+        ;; Select and partially sort top-scoring instances for crossover
+        ($sortedList (List.partialSort instance> $newInst $nToSort Nil))
+    )
+       (if (== $sortedList Nil)
+            $deme
+            (let* (
+
+                ;; Select top-K instances to form crossover pool
+                ($instList (List.takeN $nToSort $sortedList))
+
+                ;; Generate newInstances by crossing each higher-score instance with all lower-score ones
+                ($newInstances (crossPairs $instList $baseInstance $nToMakeNew))
+            )
+            (mkDeme 
+                (mkRep (mkKbMap $dscKbMp (mkDscMp $dscMp)) $tree)
+                (mkSInstSet (List.appendList (exprToList $newInstances) $instSet))
+                 $demeId)
+           )
+        ))
+)
+
+
+
+; ~/PeTTa/run.sh cross-top-two.metta
+
+
+

--- a/optimization/hillclimbing/hill-climbing-helpers.metta
+++ b/optimization/hillclimbing/hill-climbing-helpers.metta
@@ -119,12 +119,27 @@
 ;; Crossover function.
 ;; (: crossTopOne (-> Deme Number Number Number Instance Deme))
 ; (: crossover (-> Number Number Instance Deme (Deme Number)))
-(= (crossover $demeSize $nNewInstances $sampleStart $sampleSize $centerInst $deme)
-   ;; (trace! (Running crossover to make: (min $nNewInstances 120) instances)
-   ;; INFO: The 120 is crossover_pop_size parameter that should come from hillClimbing
-           ((crossTopOne $deme (min $nNewInstances 120) $sampleStart $sampleSize $centerInst) (if (< (- $sampleSize 1) $nNewInstances) (- $sampleSize 1) $nNewInstances))
-   ;; )
-   ) ;; WARN: The $nNewInstances might not be the actual number of instances created.
+; (= (crossover $demeSize $nNewInstances $sampleStart $sampleSize $centerInst $deme)
+;    ;; (trace! (Running crossover to make: (min $nNewInstances 120) instances)
+;    ;; INFO: The 120 is crossover_pop_size parameter that should come from hillClimbing
+;    ;  ((crossTopOne $deme (min $nNewInstances 120) $sampleStart $sampleSize $centerInst) (if (< (- $sampleSize 1) $nNewInstances) (- $sampleSize 1) $nNewInstances))
+(let*
+    (
+      ($nToMake (min $nNewInstances 120))
+      ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
+      
+      ($newInst1 (crossTopOne $instSet (+ (/ $nToMake 3) (% $nToMake 3)) $sampleStart $sampleSize $centerInst))
+      ($newInst2 (crossTopTwo $instSet (/ $nToMake 3) $sampleStart $sampleSize $centerInst))
+      ($newInst3 (crossTopThree $instSet $n3 $sampleStart $sampleSize $centerInst))
+      ($allNewInst (List.appendList $newInst1
+                 (List.appendList $newInst2 $newInst3)))
+
+      ($finalSet (List.appendList $allNewInst $instSet))
+    )
+    (mkDeme $rep (mkSInstSet $finalSet) $id)
+  )
+;     ; )
+;    ) ;; WARN: The $nNewInstances might not be the actual number of instances created.
 
 ;; crossover for feature selection
 ; (: crossoverFs (-> Number Number Instance (InstanceSet $a) ((InstanceSet $a) Number)))

--- a/optimization/hillclimbing/test/cross-top-three-test.metta
+++ b/optimization/hillclimbing/test/cross-top-three-test.metta
@@ -1,0 +1,167 @@
+
+!(import! &self ../../../../metta-moses/utilities/general-helpers)
+!(import! &self ../../../../metta-moses/utilities/list-methods)
+!(import! &self ../../../../metta-moses/representation/instance)
+!(import! &self ../../../../metta-moses/representation/representation)
+!(import! &self ../../../../metta-moses/representation/create-representation)
+!(import! &self ../../../../metta-moses/scoring/cscore)
+!(import! &self ../../../../metta-moses/deme/create-deme)
+
+
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-one-helpers)
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-one)
+
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-three-helpers)
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-three)
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-two-helpers)
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-two)
+
+
+
+;;  -------Test Cases-----------
+
+
+;; --- getInst test --
+;; Ensures getInst correctly extracts raw instance from mkSInst wrapper
+!(assertEqual
+  (getInst (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 1))))
+  (mkInst (Cons 5 Nil)))
+
+;; --- mergeTriple test --
+;; Tests sequential 3-step merge: k → iRef → jRef
+;; NOTE: expected result should validate final merged scored instance 
+;;expected : (mkSInst (mkPair (mkInst (Cons b (Cons 2 Nil))) (mkCscore (its score))))
+     
+!(mergeTriple
+   (getInst
+     (mkSInst (mkPair (mkInst (Cons a (Cons 5 Nil))) (mkCscore 0 0 0 0 1))))
+    (mkInst (Cons a (Cons 0 Nil)))
+   (getInst
+     (mkSInst (mkPair (mkInst (Cons b (Cons  3 Nil))) (mkCscore 0 0 0 0 2))))
+   (getInst
+       (mkSInst (mkPair (mkInst (Cons a (Cons 2 Nil))) (mkCscore 0 0 0 0 3)))))
+
+;; Verifies inner loop respects generation limit constraint
+  !(assertEqual
+  (List.length
+    (crossInnerLoop
+      (Cons
+        (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 1)))
+        (Cons
+          (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+          (Cons
+            (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+            Nil)))
+      (mkInst (Cons 9 Nil))
+      (mkInst (Cons 8 Nil))
+      (mkInst (Cons 0 Nil))
+      Nil
+      3))
+  3)
+
+
+ ;; Runs k-level crossover loop 
+!(crossInnerLoop
+      (Cons
+        (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 1)))
+        (Cons
+          (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+          (Cons
+            (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+            Nil)))
+      (mkInst (Cons 9 Nil))   
+      (mkInst (Cons 8 Nil))   
+      (mkInst (Cons 0 Nil))  
+         Nil                  
+           3 )
+
+  ;; Checks j-loop aggregation over multiple k-combinations
+;; Ensures correct propagation of inner loop results
+  !(assertEqual
+       (List.length
+            (crossMiddleLoop
+            (Cons
+              (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+              (Cons
+                (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+                Nil))
+
+            (mkInst (Cons 9 Nil))
+
+            (Cons
+              (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 1)))
+              (Cons
+                (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+                (Cons
+                  (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+                  Nil)))
+                
+            (mkInst (Cons 0 Nil))
+            Nil
+            4))
+            4)
+
+ ;; Executes full i-j-k crossover pipeline 
+;; Used for manual verification/debugging   
+!(crossOuterLoop
+         (Cons
+            (mkSInst (mkPair (mkInst (Cons 1 Nil)) (mkCscore 0 0 0 0 1)))
+            (Cons
+               (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 2)))
+               (Cons
+                  (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 3)))
+                  (Cons
+                     (mkSInst (mkPair (mkInst (Cons 4 Nil)) (mkCscore 0 0 0 0 4)))
+                     Nil))))
+         (mkInst (Cons 0 Nil))
+         2)
+;; Ensures outer loop respects global generation limit
+!(assertEqual
+   (List.length
+      (crossOuterLoop
+         (Cons
+            (mkSInst (mkPair (mkInst (Cons 1 Nil)) (mkCscore 0 0 0 0 1)))
+            (Cons
+               (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 2)))
+               (Cons
+                  (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 3)))
+                  Nil)))
+         (mkInst (Cons 0 Nil))
+         4))
+         4)
+
+
+
+
+
+(= (deme3)
+          (mkDeme
+            (mkRep
+              (mkKbMap (mkDscKbMp (ConsMap NilMap)) (mkDscMp NilMMap))
+              (mkTree (mkNode A) Nil))
+
+            (mkSInstSet
+
+              (Cons
+                (mkSInst (mkPair (mkInst (Cons a (Cons 1 Nil))) (mkCscore 0 0 0 0 1)))
+                (Cons
+                  (mkSInst (mkPair (mkInst (Cons b (Cons 2 Nil))) (mkCscore 0 0 0 0 2)))
+                  (Cons
+                    (mkSInst (mkPair (mkInst (Cons c (Cons 3 Nil))) (mkCscore 0 0 0 0 3)))
+                    (Cons
+                      (mkSInst (mkPair (mkInst (Cons a (Cons 4 Nil))) (mkCscore 0 0 0 0 4)))
+                      Nil)))))
+
+            (mkDemeId "3")))
+
+
+
+;; Full system test: 3-simplex crossover on deme3
+;; Validates end-to-end pipeline behavior
+!(crossTopThree (deme3) 2 0 5 (mkInst (Cons b (Cons 2 Nil))))
+
+  
+  
+
+
+   

--- a/optimization/hillclimbing/test/cross-top-two-test.metta
+++ b/optimization/hillclimbing/test/cross-top-two-test.metta
@@ -1,0 +1,93 @@
+!(import! &self ../../../../metta-moses/utilities/general-helpers)
+!(import! &self ../../../../metta-moses/utilities/list-methods)
+!(import! &self ../../../../metta-moses/representation/instance)
+!(import! &self ../../../../metta-moses/representation/representation)
+!(import! &self ../../../../metta-moses/representation/create-representation)
+!(import! &self ../../../../metta-moses/scoring/cscore)
+!(import! &self ../../../../metta-moses/deme/create-deme)
+
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-one-helpers);; To use mergeInstance
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-three-helpers);; to use getInst
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-two-helpers)
+!(import! &self ../../../../metta-moses/optimization/hillclimbing/cross-top-two)
+
+
+
+;; Test deme: small population with simple integer instances and fixed scores
+(= (deme2)
+   (mkDeme
+       (mkRep
+           (mkKbMap
+              (mkDscKbMp (ConsMap NilMap))
+              (mkDscMp NilMMap))
+           (mkTree (mkNode A) Nil))
+        (mkSInstSet
+            (Cons (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 1 0 0 0 3)))
+            (Cons (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 1 0 0 0 2)))
+            (Cons (mkSInst (mkPair (mkInst (Cons 1 Nil)) (mkCscore 1 0 0 0 1)))
+            (Cons (mkSInst (mkPair (mkInst (Cons 4 Nil)) (mkCscore 1 0 0 0 4)))
+            Nil)))))
+    (mkDemeId "2")
+    )
+)
+
+
+;;        ---Test cases----
+   
+;; Test merge of target instance with reference instance using base instance
+;; Checks correct behavior of mergeInstance wrapper 
+!(mergeTargetToRef
+   (getInst
+     (mkSInst (mkPair (mkInst (Cons a (Cons 5 Nil))) (mkCscore 0 0 0 0 1))))
+     (mkInst (Cons a (Cons 0 Nil)))
+    (getInst
+     (mkSInst (mkPair (mkInst (Cons b (Cons 3 Nil))) (mkCscore 0 0 0 0 2)))))
+
+
+;; Test inner crossover loop
+;; Crosses a reference instance against a list of candidate instances
+  !(crossPairsToRef
+      (Cons
+        (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+        (Cons
+          (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+          Nil))
+      (getInst
+          (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 3))))
+        (mkInst (Cons 9 Nil))
+      Nil
+      2
+)
+
+;; Test outer crossover loop
+;; Ensures full pair generation from a candidate list
+!(crossPairs
+      (Cons
+        (mkSInst (mkPair (mkInst (Cons 3 Nil)) (mkCscore 0 0 0 0 2)))
+        (Cons
+          (mkSInst (mkPair (mkInst (Cons 2 Nil)) (mkCscore 0 0 0 0 3)))
+          (Cons
+          (mkSInst (mkPair (mkInst (Cons 5 Nil)) (mkCscore 0 0 0 0 3)))
+          Nil)))
+         (mkInst (Cons 9 Nil))
+         3
+      )
+   
+;; Full integration test for crossTopTwo
+;; Runs 2-simplex crossover on deme and verifies final merged deme output
+!(crossTopTwo (deme2)  5  0 10 (mkInst (Cons 4 Nil)))
+
+
+
+
+
+
+   
+  
+
+
+
+
+
+
+  

--- a/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
+++ b/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
@@ -24,6 +24,10 @@
 
 !(import! &self ../cross-top-one-helpers)
 !(import! &self ../cross-top-one)
+!(import! &self ../cross-top-two-helpers)
+!(import! &self ../cross-top-two)
+!(import! &self ../cross-top-three-helpers)
+!(import! &self ../cross-top-three)
 
 
 
@@ -251,3 +255,22 @@
 !(assertEqual (hillClimbing (strategyDeme) (mkCscore 3.0 5 1.43 0.0 3) (mkInst (Cons 1 (Cons 1 Nil))) (mkParams applyStrategyBasedScore (3 random-player 3.5))) 
                     ((mkInst (Cons 1 (Cons 1 Nil))) (mkDeme (mkRep (mkKbMap (mkDscKbMp (ConsMap ((mkNodeId (1)) 0) (ConsMap ((mkNodeId (2)) 1) NilMap))) (mkDscMp (ConsMMap ((mkDiscSpec 2) (mkSSK (mkDiscKnob (mkKnob (mkNodeId (1))) (mkMultip 2) (mkDiscSpec 1) (mkDiscSpec 1) Nil))) (ConsMMap ((mkDiscSpec 2) (mkSSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 2) (mkDiscSpec 1) (mkDiscSpec 1) Nil))) NilMMap)))) (mkTree (mkNode PRIORITIZED-OR) (Cons (mkTree (mkNode playwin) Nil) (Cons (mkTree (mkNode playblock) Nil) Nil)))) (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 Nil))) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))) (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 1 Nil))) (mkCscore -3.0 2 0.5714285714285714 0.0 -3.571428571428571))) (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 Nil))) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))) (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 0 Nil))) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))) Nil))))) (mkDemeId "1")) (true false false (mkInst (Cons 1 (Cons 1 Nil))) 3 1 (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856) -3.2857142857142856 4 2 3))
 )
+!(let
+    ($d1 (crossTopOne (deme1) 3 0 4 (mkInst (Cons 0 Nil))))
+    ($d2 (crossTopTwo $d1 3 0 4 (mkInst (Cons 0 Nil))))
+    (assertTrue (not (== $d2 Nil))))
+
+    !(let
+    ($d1 (crossTopOne (deme1) 3 0 4 (mkInst (Cons 0 Nil))))
+    ($d2 (crossTopTwo $d1 3 0 4 (mkInst (Cons 0 Nil))))
+    (assertTrue
+        (> (List.length (mkSInstSet $d2))
+           (List.length (mkSInstSet (deme1))))))
+           !(let
+    ($d2 (crossTopTwo 
+            (crossTopOne (deme1) 3 0 4 (mkInst (Cons 0 Nil)))
+            3 0 4 (mkInst (Cons 0 Nil))))
+    (assertTrue (not (== $d2 (deme1)))))
+
+; ~/PeTTa/run.sh hillclimbing-helpers-test.metta
+


### PR DESCRIPTION
## Purpose
Introduce multi-parent crossover operators to improve exploration in hill climbing:
- `crossTopTwo` → pairwise crossover
- `crossTopThree` → 3-simplex crossover

## What’s included
- Added `crossTopTwo` with pairwise instance merging
- Added `crossTopThree` with triple-instance merging
- Implemented structured loop hierarchy (inner / middle / outer)
- Added helper functions for instance extraction and merging
- Added unit tests for loop components and top-level functions

## Key idea
Instead of crossing a single parent with others, this introduces:
- pairwise recombination (2-parent)
- triple recombination (3-parent)

This enables richer interaction between high-quality candidates and improves diversity of generated instances.

## Notes for reviewers
**Recommended review order:**
1. `cross-top-two-helpers.metta`
2. `cross-top-two.metta`
3. `cross-top-three-helpers.metta`
4. `cross-top-three.metta`
5. `test/cross-top-two-test.metta`
6. `test/cross-top-three-test.metta`

## Testing
- Unit tests added for:
  - merge helpers
  - loop structures (inner / middle / outer)
- Structural tests validate limit constraints on generated instances