### PR TITLE
fix: corrected the state update of the best score in the hillclimbing 

### DIFF
--- a/optimization/hillclimbing/hill-climbing-helpers.metta
+++ b/optimization/hillclimbing/hill-climbing-helpers.metta
@@ -325,6 +325,8 @@
         ;; ($_ (println! ""))
 
         ($nextCenterInst (if $hasImproved (Pair.first $newBestInstPair) $centerInst))
+        ($nextBestScore (if $hasImproved $newBestScore $bestScore))
+        ($nextBestSscore (if $hasImproved (Pair.second $newBestInstPair) $bestSscore))
         ($nextDistance (if $hasImproved 1 (if (not $xOver) (+ 1 $d) $d)))
         
         ;; ($_ (println! (NextDistance: $nextDistance)))
@@ -332,13 +334,13 @@
         (($newCenter $newDeme ($newXover $newLastChance $newHasImproved $newPrevCenter $newPrevStart $newPrevSize $newBestSscore $nextNewBestScore $newCurrentNInstance $newDistance $newI))
                               (if (and (== $totalNNeighbors 1) (== $nextDistance 1))
                                   (hillClimbing ($maxDist $minXoverNeighbors $bestPossibleScore)
-                                                ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $prevStart $prevSize (Pair.second $newBestInstPair) $newBestScore (+ $currentNInstances $newInstances) $nextDistance (+ 1 $i)) ;; Updated state
+                                                ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $prevStart $prevSize $nextBestSscore $nextBestScore (+ $currentNInstances $newInstances) $nextDistance (+ 1 $i)) ;; Updated state
                                                 $updatedDeme
                                                 ($neighborhood $rowOCoeff $size $iTable)
                                                 $nextCenterInst
                                                 $hyperparamsfs
                                                 $estimateFunction $crossoverFunction $samplingFunction $transformFunction)
-                                  ($nextCenterInst $updatedDeme ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $currentNInstances $newInstances (Pair.second $newBestInstPair) $newBestScore (+ $currentNInstances $newInstances) $nextDistance $i))))
+                                  ($nextCenterInst $updatedDeme ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $currentNInstances $newInstances $nextBestSscore $nextBestScore (+ $currentNInstances $newInstances) $nextDistance $i))))
         
         ($scoreToCompareBelow (if (or (== $rep ()) (== $id ())) $newBestSscore (getPenScore $newBestSscore)))
         ;; ($_ (println! (Found newBestSscore After (+ 1 $i) iteration is: $newBestSscore $scoreToCompareBelow)))

--- a/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
+++ b/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
@@ -229,6 +229,17 @@
      ((>= $instanceCount 3) (List.any $scoredElems)))
    (True True))
 
+;; Checks the returned center instance is either the absolute best instance found in the deme, or if not, that the gap between the best instance's score and the original center's score is within the improvement threshold (0.5)
+;; It uses (mkInst (cons 2 (cons 2 ()))) as the first center instance which has a penalty score of -5  
+!(assertEqual 
+  (let* 
+  (
+    (($instance (mkDeme $rep (mkSInstSet $sInstSet) $demeId) $state) (hillClimbing (deme) (table1) (mkInst (cons 2 (cons 2 ()))) (mkParams applyComplexityBasedScore ())))
+    ((mkSInst (mkPair $bestInst $bestScore)) (List.foldl hillScoreHelper (mkSInst (mkPair (mkInst (2 2)) (mkCscore -4 2 1.0 0.0 -5.0))) $sInstSet))
+  )
+  (or (== $instance $bestInst) (<= (- (getPenScore $bestScore) -5) 0.5))
+) True)
+
 ;; deme for strategy hill climbing
 (= (strategyDeme)
    (mkDeme 


### PR DESCRIPTION
There was an issue with the hill climbing optimization implementation where $bestScore and $bestSscore were updated unconditionally every iteration, regardless of whether a meaningful improvement had occurred. The $hasImproved check, which determines whether the new score exceeds the previous best by a threshold of 0.5, was only applied to the center instance update, not to the score state update. This created a misalignment between the center instance and its corresponding best score: the score baseline would drift to reflect a candidate that was never actually adopted as the new center, causing subsequent $hasImproved checks to compare against an inconsistent reference point.

This fix ensures that $bestScore and $bestSscore are only updated when $hasImproved is True, keeping them consistent with the current center instance at every iteration. This also improves the performance of the optimization algorithm by preventing premature score inflation from raising the improvement threshold, which previously caused genuinely better candidates to be incorrectly rejected and the search to terminate earlier than it should have.

## How Has This Been Tested?
It has been tested with the latest version of petta. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
