### PR TITLE
Action Selection Knob Building

### DIFF
--- a/representation/build-action.metta
+++ b/representation/build-action.metta
@@ -1,0 +1,197 @@
+;; =============================================================================
+;; build-action.metta
+;;
+;; Action-domain knob building for action selection trees. This ports the
+;; action-selection branch onto dev's embedded mkKnob representation style.
+;; =============================================================================
+
+(= (randElement $list)
+   (if (== $list ())
+       ()
+       (let* (($len (length $list))
+              ($idx (py-call (random.randint 0 (- $len 1)))))
+         (List.getByIdx $list $idx))))
+
+(= (randint $max) (py-call (random.randint 0 $max)))
+
+(= (isActionOperator $op)
+   (is-member $op (and_seq or_seq seq_exec action_not action_bool_if
+                   bool_action_if contin_action_if action_action_if
+                   action_success action_failure
+                   action_while bool_while return_success repeat_n)))
+
+(= (isBuiltinAction $op) (not (isActionOperator $op)))
+(= (isBuiltinAction $op $actions) (is-member $op $actions))
+
+(= (sampleActionPerms $actions $perceptions)
+   (if (== $perceptions ())
+       $actions
+       (sampleActionPerms $actions $perceptions (length $actions))))
+
+(= (sampleActionPerms $actions $perceptions $n)
+   (let $actionCount (length $actions)
+     (if (or (== $n 0) (< $actionCount 2))
+         $actions
+         (let*
+           (
+             ($pairCount (* $actionCount (- $actionCount 1)))
+             ($sampleCount (if (> $n $pairCount) $pairCount $n))
+             ($pairIdxs (lazyRandomSelector 0 (- $pairCount 1) $sampleCount))
+             ($pairs (actionPairsFromIndexes $pairIdxs $perceptions $actions $actionCount))
+           )
+           (concatT $actions $pairs)))))
+
+(= (actionPairFromIndex $perceptions $actions $actionCount $pairIdx)
+   (let*
+     (
+       ($width (- $actionCount 1))
+       ($aIdx (int (/ $pairIdx $width)))
+       ($bRaw (- $pairIdx (* $aIdx $width)))
+       ($bIdx (if (== $bRaw $aIdx) (- $actionCount 1) $bRaw))
+       ($perception (randElement $perceptions))
+       ($actA (List.getByIdx $actions $aIdx))
+       ($actB (List.getByIdx $actions $bIdx))
+     )
+     (action_bool_if $perception $actA $actB)))
+
+(= (actionPairsFromIndexes () $perceptions $actions $actionCount) ())
+(= (actionPairsFromIndexes (cons $pairIdx $rest) $perceptions $actions $actionCount)
+   (cons (actionPairFromIndex $perceptions $actions $actionCount $pairIdx)
+         (actionPairsFromIndexes $rest $perceptions $actions $actionCount)))
+
+(= (registerActionKnob $controlledSubtree $ask $MMap)
+   (let*
+     (
+       ($index (get-state &knobCount))
+       ($_ (incrementState &knobCount 1))
+       ($knobChild (mkKnob $controlledSubtree $ask $index))
+       ($mmp (expToMMap (((getKnobSpec $ask) $ask)) $MMap discSpec<))
+     )
+     ($knobChild $mmp)))
+
+(= (makeActionInsertionKnob $actions $perceptions $MMap)
+   (let*
+     (
+       ($perms (sampleActionPerms $actions $perceptions))
+       ($treePerms (map-atom $perms $perm (buildTree $perm)))
+     )
+     (if (== $perms ())
+         (() $MMap)
+         (let*
+           (
+             (($controlledSubtree $ask) (actionSubtreeKnob $treePerms))
+             (($knobChild $mmp) (registerActionKnob $controlledSubtree $ask $MMap))
+           )
+           ($knobChild $mmp)))))
+
+(= (wrapSimpleActionSubtree $subtree $MMap)
+   (let*
+     (
+       (($controlledSubtree $ask) (simpleActionSubtreeKnob $subtree))
+       (($knobChild $mmp) (registerActionKnob $controlledSubtree $ask $MMap))
+     )
+     ($knobChild $mmp)))
+
+(= (appendActionInsertionChild $children $MMap $actions $perceptions)
+   (let ($knobChild $mmp) (makeActionInsertionKnob $actions $perceptions $MMap)
+     (if (== $knobChild ())
+         ($children $mmp)
+         ((append $children ($knobChild)) $mmp))))
+
+(= (buildActionChildren () $MMap $actions $perceptions) (() $MMap))
+(= (buildActionChildren (cons $child $rest) $MMap $actions $perceptions)
+   (let*
+     (
+       (($updatedChild $m1) (buildActionChild $child $MMap $actions $perceptions))
+       (($updatedRest $m2) (buildActionChildren $rest $m1 $actions $perceptions))
+     )
+     ((cons $updatedChild $updatedRest) $m2)))
+
+(= (buildActionChild (mkTree (mkNode $op) $children) $MMap $actions $perceptions)
+   (let $child (mkTree (mkNode $op) $children)
+     (if (isBuiltinAction $op $actions)
+         (wrapSimpleActionSubtree $child $MMap)
+         (if (== $op and_seq)
+             (buildActionTree $child $MMap $actions $perceptions)
+             (if (== $op action_bool_if)
+                 (let ($updatedChild $m1) (buildActionTree $child $MMap $actions $perceptions)
+                   (wrapSimpleActionSubtree $updatedChild $m1))
+                 ($child $MMap))))))
+
+(= (buildActionChild $child $MMap $actions $perceptions)
+   ($child $MMap))
+
+(= (buildActionBoolIfBranches () $MMap $actions $perceptions) (() $MMap))
+(= (buildActionBoolIfBranches (cons $child $rest) $MMap $actions $perceptions)
+   (let*
+     (
+       (($updatedChild $m1) (buildActionBoolIfBranch $child $MMap $actions $perceptions))
+       (($updatedRest $m2) (buildActionBoolIfBranches $rest $m1 $actions $perceptions))
+     )
+     ((cons $updatedChild $updatedRest) $m2)))
+
+(= (buildActionBoolIfBranch (mkTree (mkNode $op) $children) $MMap $actions $perceptions)
+   (let $branch (mkTree (mkNode $op) $children)
+     (if (isBuiltinAction $op $actions)
+         (buildActionTree (mkTree (mkNode and_seq) (cons $branch ())) $MMap $actions $perceptions)
+         (if (or (== $op and_seq) (== $op action_bool_if))
+             (buildActionTree $branch $MMap $actions $perceptions)
+             ($branch $MMap)))))
+
+(= (buildActionBoolIfBranch $branch $MMap $actions $perceptions)
+   ($branch $MMap))
+
+(= (buildActionTree (mkTree (mkNode and_seq) $children) $MMap $actions $perceptions)
+   (let*
+     (
+       (($updatedChildren $m1) (buildActionChildren $children $MMap $actions $perceptions))
+       (($finalChildren $m2) (appendActionInsertionChild $updatedChildren $m1 $actions $perceptions))
+     )
+     ((mkTree (mkNode and_seq) $finalChildren) $m2)))
+
+(= (buildActionTree (mkTree (mkNode action_bool_if) ()) $MMap $actions $perceptions)
+   ((mkTree (mkNode action_bool_if) ()) $MMap))
+(= (buildActionTree (mkTree (mkNode action_bool_if) (cons $perception $branches)) $MMap $actions $perceptions)
+   (let ($updatedBranches $m1) (buildActionBoolIfBranches $branches $MMap $actions $perceptions)
+     ((mkTree (mkNode action_bool_if) (cons $perception $updatedBranches)) $m1)))
+
+(= (buildAction $tree (mkNodeId $nodeId) $MMap $actions $perceptions)
+   (let $subtree (getNodeById $tree (mkNodeId $nodeId))
+     (if (or (== $subtree ()) (isNullVertex $subtree))
+         ($tree $MMap)
+         (let ($updatedSubtree $m1) (buildActionTree $subtree $MMap $actions $perceptions)
+           ((replaceNodeById $tree (mkNodeId $nodeId) $updatedSubtree) $m1)))))
+
+(= (isCleanupActionOperator $op)
+   (is-member $op (and_seq or_seq seq_exec)))
+
+(= (actionCleanup $tree)
+   (let ($cleaned $keep) (actionCleanupNode $tree)
+     (if $keep $cleaned (mkNullVex ()))))
+
+(= (actionCleanupNode (mkNullVex $children))
+   ((mkNullVex $children) True))
+(= (actionCleanupNode (mkKnob $subtree $knob $i))
+   ((mkKnob $subtree $knob $i) True))
+(= (actionCleanupNode (mkTree (mkNode $rootOp) $children))
+   (let $cleanedChildren (actionCleanupChildren $children)
+     (if (and (== $cleanedChildren ()) (isCleanupActionOperator $rootOp))
+         ((mkNullVex ()) False)
+         ((mkTree (mkNode $rootOp) $cleanedChildren) True))))
+
+(= (actionCleanupChildren ()) ())
+(= (actionCleanupChildren (cons $child $rest))
+   (let*
+     (
+       (($cleanedChild $keep) (actionCleanupNode $child))
+       ($cleanedRest (actionCleanupChildren $rest))
+     )
+     (if $keep
+         (cons $cleanedChild $cleanedRest)
+         $cleanedRest)))
+
+(= (actionCanonize $tree)
+   (let (mkTree (mkNode $rootOp) $children) $tree
+     (if (== $rootOp and_seq)
+         $tree
+         (insertNodeAtPosition $tree (mkNodeId (0)) (mkNode and_seq)))))

--- a/representation/build-action.metta
+++ b/representation/build-action.metta
@@ -1,8 +1,7 @@
 ;; =============================================================================
 ;; build-action.metta
 ;;
-;; Action-domain knob building for action selection trees. This ports the
-;; action-selection branch onto dev's embedded mkKnob representation style.
+;; Action-domain knob building, mirroring the action section of C++ build_knobs.cc.
 ;; =============================================================================
 
 (= (randElement $list)
@@ -14,14 +13,7 @@
 
 (= (randint $max) (py-call (random.randint 0 $max)))
 
-(= (isActionOperator $op)
-   (is-member $op (and_seq or_seq seq_exec action_not action_bool_if
-                   bool_action_if contin_action_if action_action_if
-                   action_success action_failure
-                   action_while bool_while return_success repeat_n)))
-
-(= (isBuiltinAction $op) (not (isActionOperator $op)))
-(= (isBuiltinAction $op $actions) (is-member $op $actions))
+(= (isDomainAction $op $actions) (is-member $op $actions))
 
 (= (sampleActionPerms $actions $perceptions)
    (if (== $perceptions ())
@@ -59,108 +51,119 @@
    (cons (actionPairFromIndex $perceptions $actions $actionCount $pairIdx)
          (actionPairsFromIndexes $rest $perceptions $actions $actionCount)))
 
-(= (registerActionKnob $controlledSubtree $ask $MMap)
-   (let*
-     (
-       ($index (get-state &knobCount))
-       ($_ (incrementState &knobCount 1))
-       ($knobChild (mkKnob $controlledSubtree $ask $index))
-       ($mmp (expToMMap (((getKnobSpec $ask) $ask)) $MMap discSpec<))
-     )
-     ($knobChild $mmp)))
-
-(= (makeActionInsertionKnob $actions $perceptions $MMap)
+;; Add one action-subtree ASK at the target node.
+(= (addActionKnobsAt $tree $probeRootId (mkNodeId $tgtId) $addIfInExemplar $MMap $actions $perceptions)
    (let*
      (
        ($perms (sampleActionPerms $actions $perceptions))
        ($treePerms (map-atom $perms $perm (buildTree $perm)))
+       (($knobs $updatedTree) (actionProbe $tree (mkNodeId $tgtId) $treePerms $addIfInExemplar ()))
+       ($pairs (pairKnobWithSpec $knobs))
+       ($mmp (expToMMap $pairs $MMap discSpec<))
      )
-     (if (== $perms ())
-         (() $MMap)
-         (let*
-           (
-             (($controlledSubtree $ask) (actionSubtreeKnob $treePerms))
-             (($knobChild $mmp) (registerActionKnob $controlledSubtree $ask $MMap))
-           )
-           ($knobChild $mmp)))))
+     ($updatedTree $mmp)))
 
-(= (wrapSimpleActionSubtree $subtree $MMap)
+;; Add one simple-action ASK over an existing subtree.
+(= (addSimpleActionKnobsAt $tree $probeRootId (mkNodeId $tgtId) $addIfInExemplar $MMap $actions $perceptions)
    (let*
      (
-       (($controlledSubtree $ask) (simpleActionSubtreeKnob $subtree))
-       (($knobChild $mmp) (registerActionKnob $controlledSubtree $ask $MMap))
+       (($knobs $updatedTree) (simpleActionProbe $tree (mkNodeId $tgtId) $addIfInExemplar ()))
+       ($pairs (pairKnobWithSpec $knobs))
+       ($mmp (expToMMap $pairs $MMap discSpec<))
      )
-     ($knobChild $mmp)))
+     ($updatedTree $mmp)))
 
-(= (appendActionInsertionChild $children $MMap $actions $perceptions)
-   (let ($knobChild $mmp) (makeActionInsertionKnob $actions $perceptions $MMap)
-     (if (== $knobChild ())
-         ($children $mmp)
-         ((append $children ($knobChild)) $mmp))))
+;; Process one child of and_seq. This preserves the C++ p=80 policy.
+(= (processActionChildAt $tree (mkNodeId $parentId) (mkNodeId $childId) $child $MMap $actions $perceptions $p)
+   (let (mkTree (mkNode $childOp) $_) $child
+      (if (isDomainAction $childOp $actions)
+          (if (> (randint 99) $p)
+              (addSimpleActionKnobsAt $tree $parentId (mkNodeId $childId) True $MMap $actions $perceptions)
+              (let $wrappedTree (insertNodeAtPosition $tree (mkNodeId $childId) (mkNode and_seq))
+                 (addActionKnobsAt $wrappedTree $parentId (mkNodeId $childId) False $MMap $actions $perceptions)))
+          (if (== $childOp action_bool_if)
+              (if (>= (randint 99) $p)
+                  (let ($t1 $m1) (addSimpleActionKnobsAt $tree $parentId (mkNodeId $childId) True $MMap $actions $perceptions)
+                      (buildAction $t1 (mkNodeId $childId) $m1 $actions $perceptions))
+                  (buildAction $tree (mkNodeId $childId) $MMap $actions $perceptions))
+              ($tree $MMap)))))
 
-(= (buildActionChildren () $MMap $actions $perceptions) (() $MMap))
-(= (buildActionChildren (cons $child $rest) $MMap $actions $perceptions)
+(= (processActionChildren $tree (mkNodeId $parentId) () $childIdx $MMap $actions $perceptions $p)
+   ($tree $MMap))
+
+(= (processActionChildren $tree (mkNodeId $parentId) (cons $child $rest) $childIdx $MMap $actions $perceptions $p)
    (let*
      (
-       (($updatedChild $m1) (buildActionChild $child $MMap $actions $perceptions))
-       (($updatedRest $m2) (buildActionChildren $rest $m1 $actions $perceptions))
+       ($childId (if (== $parentId (0)) ($childIdx) (concatT $parentId ($childIdx))))
+       (($t1 $m1) (processActionChildAt $tree (mkNodeId $parentId) (mkNodeId $childId) $child $MMap $actions $perceptions $p))
      )
-     ((cons $updatedChild $updatedRest) $m2)))
+     (processActionChildren $t1 (mkNodeId $parentId) $rest (+ $childIdx 1) $m1 $actions $perceptions $p)))
 
-(= (buildActionChild (mkTree (mkNode $op) $children) $MMap $actions $perceptions)
-   (let $child (mkTree (mkNode $op) $children)
-     (if (isBuiltinAction $op $actions)
-         (wrapSimpleActionSubtree $child $MMap)
-         (if (== $op and_seq)
-             (buildActionTree $child $MMap $actions $perceptions)
-             (if (== $op action_bool_if)
-                 (let ($updatedChild $m1) (buildActionTree $child $MMap $actions $perceptions)
-                   (wrapSimpleActionSubtree $updatedChild $m1))
-                 ($child $MMap))))))
+;; Process action_bool_if branches. Child 1 is perception and is skipped.
+(= (processActionBoolIfChildAt $tree (mkNodeId $parentId) (mkNodeId $childId) $child $MMap $actions $perceptions)
+   (let (mkTree (mkNode $childOp) $_) $child
+      (if (isDomainAction $childOp $actions)
+          (let $wrappedTree (insertNodeAtPosition $tree (mkNodeId $childId) (mkNode and_seq))
+            (addActionKnobsAt $wrappedTree $parentId (mkNodeId $childId) False $MMap $actions $perceptions))
+          (if (== $childOp and_seq)
+              (buildAction $tree (mkNodeId $childId) $MMap $actions $perceptions)
+              ($tree $MMap)))))
 
-(= (buildActionChild $child $MMap $actions $perceptions)
-   ($child $MMap))
+(= (processActionBoolIfChildren $tree (mkNodeId $parentId) () $childIdx $MMap $actions $perceptions)
+   ($tree $MMap))
 
-(= (buildActionBoolIfBranches () $MMap $actions $perceptions) (() $MMap))
-(= (buildActionBoolIfBranches (cons $child $rest) $MMap $actions $perceptions)
-   (let*
-     (
-       (($updatedChild $m1) (buildActionBoolIfBranch $child $MMap $actions $perceptions))
-       (($updatedRest $m2) (buildActionBoolIfBranches $rest $m1 $actions $perceptions))
-     )
-     ((cons $updatedChild $updatedRest) $m2)))
+(= (processActionBoolIfChildren $tree (mkNodeId $parentId) (cons $child $rest) $childIdx $MMap $actions $perceptions)
+   (if (== $childIdx 1)
+       (processActionBoolIfChildren $tree (mkNodeId $parentId) $rest (+ $childIdx 1) $MMap $actions $perceptions)
+       (let*
+         (
+           ($childId (if (== $parentId (0)) ($childIdx) (concatT $parentId ($childIdx))))
+           (($t1 $m1) (processActionBoolIfChildAt $tree (mkNodeId $parentId) (mkNodeId $childId) $child $MMap $actions $perceptions))
+         )
+         (processActionBoolIfChildren $t1 (mkNodeId $parentId) $rest (+ $childIdx 1) $m1 $actions $perceptions))))
 
-(= (buildActionBoolIfBranch (mkTree (mkNode $op) $children) $MMap $actions $perceptions)
-   (let $branch (mkTree (mkNode $op) $children)
-     (if (isBuiltinAction $op $actions)
-         (buildActionTree (mkTree (mkNode and_seq) (cons $branch ())) $MMap $actions $perceptions)
-         (if (or (== $op and_seq) (== $op action_bool_if))
-             (buildActionTree $branch $MMap $actions $perceptions)
-             ($branch $MMap)))))
+;; Handle sequential_and nodes with the fixed internal C++ probability p=80.
+(= (buildActionAndSeq $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions)
+   (let $p 80
+    (if (or (== $children ()) (< (randint 99) $p))
+        (let*
+          (
+            (($t1 $m1) (addActionKnobsAt $tree (mkNodeId $nodeId) (mkNodeId $nodeId) True $MMap $actions $perceptions))
+            (($t2 $m2) (processActionChildren $t1 (mkNodeId $nodeId) $children 1 $m1 $actions $perceptions $p))
+          )
+          (if (>= (randint 99) $p)
+              (let*
+                (
+                  ($builtTree (buildTree (and_seq)))
+                  (($t3 $newId) (appendChild $t2 (mkNodeId $nodeId) $builtTree))
+                )
+                (addActionKnobsAt $t3 (mkNodeId $nodeId) $newId False $m2 $actions $perceptions))
+              ($t2 $m2)))
+        (let ($t1 $m1) (processActionChildren $tree (mkNodeId $nodeId) $children 1 $MMap $actions $perceptions $p)
+          (if (>= (randint 99) $p)
+              (let*
+                (
+                  ($builtTree (buildTree (and_seq)))
+                  (($t2 $newId) (appendChild $t1 (mkNodeId $nodeId) $builtTree))
+                )
+                (addActionKnobsAt $t2 (mkNodeId $nodeId) $newId False $m1 $actions $perceptions))
+              ($t1 $m1))))))
 
-(= (buildActionBoolIfBranch $branch $MMap $actions $perceptions)
-   ($branch $MMap))
-
-(= (buildActionTree (mkTree (mkNode and_seq) $children) $MMap $actions $perceptions)
-   (let*
-     (
-       (($updatedChildren $m1) (buildActionChildren $children $MMap $actions $perceptions))
-       (($finalChildren $m2) (appendActionInsertionChild $updatedChildren $m1 $actions $perceptions))
-     )
-     ((mkTree (mkNode and_seq) $finalChildren) $m2)))
-
-(= (buildActionTree (mkTree (mkNode action_bool_if) ()) $MMap $actions $perceptions)
-   ((mkTree (mkNode action_bool_if) ()) $MMap))
-(= (buildActionTree (mkTree (mkNode action_bool_if) (cons $perception $branches)) $MMap $actions $perceptions)
-   (let ($updatedBranches $m1) (buildActionBoolIfBranches $branches $MMap $actions $perceptions)
-     ((mkTree (mkNode action_bool_if) (cons $perception $updatedBranches)) $m1)))
+(= (buildActionBoolIf $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions)
+   (processActionBoolIfChildren $tree (mkNodeId $nodeId) $children 1 $MMap $actions $perceptions))
 
 (= (buildAction $tree (mkNodeId $nodeId) $MMap $actions $perceptions)
-   (let $subtree (getNodeById $tree (mkNodeId $nodeId))
-     (if (or (== $subtree ()) (isNullVertex $subtree))
-         ($tree $MMap)
-         (let ($updatedSubtree $m1) (buildActionTree $subtree $MMap $actions $perceptions)
-           ((replaceNodeById $tree (mkNodeId $nodeId) $updatedSubtree) $m1)))))
+  (let $subtree (getNodeById $tree (mkNodeId $nodeId))
+    (if (or (== $subtree ()) (isNullVertex $subtree))
+        ($tree $MMap)
+        (let (mkTree (mkNode $op) $_) $subtree
+          (if (== $op and_seq)
+              (let $children (getChildren $subtree)
+                (buildActionAndSeq $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
+              (if (== $op action_bool_if)
+                  (let $children (getChildren $subtree)
+                    (buildActionBoolIf $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
+                  ($tree $MMap)))))))
 
 (= (isCleanupActionOperator $op)
    (is-member $op (and_seq or_seq seq_exec)))

--- a/representation/build-action.metta
+++ b/representation/build-action.metta
@@ -57,7 +57,8 @@
      (
        ($perms (sampleActionPerms $actions $perceptions))
        ($treePerms (map-atom $perms $perm (buildTree $perm)))
-       (($knobs $updatedTree) (actionProbe $tree (mkNodeId $tgtId) $treePerms $addIfInExemplar ()))
+       ($idx (MultiMap.length $MMap))
+       (($knobs $updatedTree) (actionProbe $tree (mkNodeId $tgtId) $treePerms $addIfInExemplar () $idx))
        ($pairs (pairKnobWithSpec $knobs))
        ($mmp (expToMMap $pairs $MMap discSpec<))
      )
@@ -67,7 +68,8 @@
 (= (addSimpleActionKnobsAt $tree $probeRootId (mkNodeId $tgtId) $addIfInExemplar $MMap $actions $perceptions)
    (let*
      (
-       (($knobs $updatedTree) (simpleActionProbe $tree (mkNodeId $tgtId) $addIfInExemplar ()))
+       ($idx (MultiMap.length $MMap))
+       (($knobs $updatedTree) (simpleActionProbe $tree (mkNodeId $tgtId) $addIfInExemplar () $idx))
        ($pairs (pairKnobWithSpec $knobs))
        ($mmp (expToMMap $pairs $MMap discSpec<))
      )
@@ -154,16 +156,33 @@
 
 (= (buildAction $tree (mkNodeId $nodeId) $MMap $actions $perceptions)
   (let $subtree (getNodeById $tree (mkNodeId $nodeId))
-    (if (or (== $subtree ()) (isNullVertex $subtree))
-        ($tree $MMap)
-        (let (mkTree (mkNode $op) $_) $subtree
-          (if (== $op and_seq)
-              (let $children (getChildren $subtree)
-                (buildActionAndSeq $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
-              (if (== $op action_bool_if)
-                  (let $children (getChildren $subtree)
-                    (buildActionBoolIf $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
-                  ($tree $MMap)))))))
+    (case $subtree
+      (
+        ((mkKnob $controlledSubtree (mkASK $discKnob $perms) $i)
+           (let*
+             (
+               ($ask (mkASK $discKnob $perms))
+               ((mkDiscSpec $defaultSetting) (getKnobDefault $ask))
+             )
+             (if (== $defaultSetting 0)
+                 ($tree $MMap)
+                 (let*
+                   (
+                     (($rebuiltSubtree $updatedMMap) (buildAction $controlledSubtree (mkNodeId (0)) $MMap $actions $perceptions))
+                     ($updatedTree (replaceNodeById $tree (mkNodeId $nodeId) (mkKnob $rebuiltSubtree $ask $i)))
+                   )
+                   ($updatedTree $updatedMMap)))))
+        ($other
+          (if (or (== $subtree ()) (isNullVertex $subtree))
+              ($tree $MMap)
+              (let (mkTree (mkNode $op) $_) $subtree
+                (if (== $op and_seq)
+                    (let $children (getChildren $subtree)
+                      (buildActionAndSeq $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
+                    (if (== $op action_bool_if)
+                        (let $children (getChildren $subtree)
+                          (buildActionBoolIf $tree (mkNodeId $nodeId) $children $MMap $actions $perceptions))
+                        ($tree $MMap))))))))))
 
 (= (isCleanupActionOperator $op)
    (is-member $op (and_seq or_seq seq_exec)))

--- a/representation/build-knobs.metta
+++ b/representation/build-knobs.metta
@@ -1,19 +1,31 @@
+;; Structural action operators are never domain actions.
+(= (isActionOperator $op)
+   (is-member $op (and_seq or_seq seq_exec action_not action_bool_if
+                   bool_action_if contin_action_if action_action_if
+                   action_success action_failure
+                   action_while bool_while return_success repeat_n)))
+
+;; MeTTa is untyped, so the supplied action domain is the source of truth.
+(= (isBuiltinAction $op $actions) (is-member $op $actions))
+
 ;;;; buildKnobs constructor that is directly called by the representaion constructor
 ;; Params: Tree (Exemplar)
 ;;         $mmp: multimap to store knobs
 ;;         $argLabels: list of argument labels (input variables) from the ITable
-;; Returns: a tuple containing the updatedTree and a multimap of $kbSpec $kb pairs 
+;; Returns: a tuple containing the updatedTree and a multimap of $kbSpec $kb pairs
  ;; (: buildKnobs (-> (Tree Bool) (MultiMap ($k $v)) Expression ((Tree $a) (MultiMap ($k $v)))))
 (= (buildKnobs $exemplar $mmp $argLabels)
     (buildKnobs $exemplar $mmp $argLabels True))
 
 (= (buildKnobs $exemplar $mmp $argLabels $disable-discprobe)
     (let (mkTree (mkNode $rootOp) $children) $exemplar
+        (if (isActionOperator $rootOp)
+            (Error "buildKnobs 4-arity cannot be called with action operator root")
         (if (== $rootOp PRIORITIZED-OR)
             (buildStrategy $exemplar (mkNodeId (0)) $mmp $argLabels)
             (let $canonized (logicalCanonize $exemplar)
                  (let (mkTree (mkNode $canonRootOp) $canonChildren) $canonized
-                      (buildLogical $canonized $canonRootOp $mmp $argLabels $disable-discprobe $canonized (mkNodeId (0))))))))
+                      (buildLogical $canonized $canonRootOp $mmp $argLabels $disable-discprobe $canonized (mkNodeId (0)))))))))
 
 (= (buildKnobs (mkTree (mkNode $rootOp) $children) $mmp $argLabels $actions $perceptions)
     (if (== $rootOp PRIORITIZED-OR)

--- a/representation/build-knobs.metta
+++ b/representation/build-knobs.metta
@@ -5,9 +5,6 @@
                    action_success action_failure
                    action_while bool_while return_success repeat_n)))
 
-;; MeTTa is untyped, so the supplied action domain is the source of truth.
-(= (isBuiltinAction $op $actions) (is-member $op $actions))
-
 ;;;; buildKnobs constructor that is directly called by the representaion constructor
 ;; Params: Tree (Exemplar)
 ;;         $mmp: multimap to store knobs

--- a/representation/build-knobs.metta
+++ b/representation/build-knobs.metta
@@ -14,3 +14,19 @@
             (let $canonized (logicalCanonize $exemplar)
                  (let (mkTree (mkNode $canonRootOp) $canonChildren) $canonized
                       (buildLogical $canonized $canonRootOp $mmp $argLabels $disable-discprobe $canonized (mkNodeId (0))))))))
+
+(= (buildKnobs (mkTree (mkNode $rootOp) $children) $mmp $argLabels $actions $perceptions)
+    (if (== $rootOp PRIORITIZED-OR)
+        (buildStrategy (mkTree (mkNode PRIORITIZED-OR) $children) (mkNodeId (0)) $mmp $argLabels)
+        (if (or (isActionOperator $rootOp) (is-member $rootOp $actions))
+            (let*
+              (
+                ($canonized (actionCanonize (mkTree (mkNode $rootOp) $children)))
+                (($updatedTree $updatedMMap) (buildAction $canonized (mkNodeId (0)) $mmp $actions $perceptions))
+                ($cleanedTree (actionCleanup $updatedTree))
+                ($finalTree (if (isNullVertex $cleanedTree) (mkTree (mkNode and_seq) ()) $cleanedTree))
+              )
+              ($finalTree $updatedMMap))
+            (let $canonized (logicalCanonize (mkTree (mkNode $rootOp) $children))
+                 (let (mkTree (mkNode $canonRootOp) $canonChildren) $canonized
+                      (buildLogical $canonized $canonRootOp $mmp $argLabels True $canonized (mkNodeId (0))))))))

--- a/representation/build-knobs.metta
+++ b/representation/build-knobs.metta
@@ -1,10 +1,3 @@
-;; Structural action operators are never domain actions.
-(= (isActionOperator $op)
-   (is-member $op (and_seq or_seq seq_exec action_not action_bool_if
-                   bool_action_if contin_action_if action_action_if
-                   action_success action_failure
-                   action_while bool_while return_success repeat_n)))
-
 ;;;; buildKnobs constructor that is directly called by the representaion constructor
 ;; Params: Tree (Exemplar)
 ;;         $mmp: multimap to store knobs

--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -35,6 +35,13 @@
 ;; (: ActionSubtreeKnob Type)
 ;; (: mkASK (-> DiscreteKnob (List (Tree $a)) ActionSubtreeKnob))
 
+;; Structural action operators are never domain actions.
+(= (isActionOperator $rootSymbol)
+   (is-member $rootSymbol (and_seq or_seq seq_exec action_not action_bool_if
+                           bool_action_if contin_action_if action_action_if
+                           action_success action_failure action_while
+                           bool_while return_success repeat_n)))
+
 ;; Checks if a DiscreteKnob is considered part of the exemplar based on its default specifier.
 ;; Params:
 ;;   $discKnob: DiscreteKnob

--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -31,6 +31,10 @@
 ;; (: StrategySubtreeKnob Type)
 ;; (: mkSSK (-> DiscreteKnob StrategySubtreeKnob))
 
+;; Action subtree knob representation
+;; (: ActionSubtreeKnob Type)
+;; (: mkASK (-> DiscreteKnob (List (Tree $a)) ActionSubtreeKnob))
+
 ;; Checks if a DiscreteKnob is considered part of the exemplar based on its default specifier.
 ;; Params:
 ;;   $discKnob: DiscreteKnob
@@ -47,8 +51,10 @@
 ;; Return: The extracted DiscKnob
 ;; (: getDiscKnob (-> LogicalSubtreeKnob DiscreteKnob))
 ;; (: getDiscKnob (-> StrategySubtreeKnob DiscreteKnob))
+;; (: getDiscKnob (-> ActionSubtreeKnob DiscreteKnob))
 (= (getDiscKnob (mkLSK $DiscKnob )) $DiscKnob)
 (= (getDiscKnob (mkSSK $DiscKnob )) $DiscKnob)
+(= (getDiscKnob (mkASK $DiscKnob $perms)) $DiscKnob)
 
 ;; Extracts the Tree component from a LogicalSubtreeKnob (mkLSK).
 ;; Params:
@@ -63,28 +69,34 @@
 ;; (: getRawKnobMultip (-> DiscreteKnob Multiplicity))
 ;; (: getRawKnobMultip (-> LogicalSubtreeKnob Multiplicity))
 ;; (: getRawKnobMultip (-> StrategySubtreeKnob Multiplicity))
+;; (: getRawKnobMultip (-> ActionSubtreeKnob Multiplicity))
 
 (= (getRawKnobMultip (mkDiscKnob $multiplicity $curr $def $disAll)) $multiplicity)
 (= (getRawKnobMultip (mkDiscKnob $knob $multiplicity $curr $def $disAll)) $multiplicity)
 (= (getRawKnobMultip (mkLSK $discKnob )) (getRawKnobMultip $discKnob))
 (= (getRawKnobMultip (mkSSK $discKnob )) (getRawKnobMultip $discKnob))
+(= (getRawKnobMultip (mkASK $discKnob $perms)) (getRawKnobMultip $discKnob))
 
 ;; Extracts the default setting and disallowed settings from a knob.
 ;; (: getKnobDefault (-> DiscreteKnob DiscSpec))
 ;; (: getKnobDefault (-> LogicalSubtreeKnob DiscSpec))
 ;; (: getKnobDefault (-> StrategySubtreeKnob DiscSpec))
+;; (: getKnobDefault (-> ActionSubtreeKnob DiscSpec))
 (= (getKnobDefault (mkDiscKnob $multiplicity $current $default $disAll)) $default)
 (= (getKnobDefault (mkDiscKnob $knob $multiplicity $current $default $disAll)) $default)
 (= (getKnobDefault (mkLSK $discKnob )) (getKnobDefault $discKnob))
 (= (getKnobDefault (mkSSK $discKnob )) (getKnobDefault $discKnob))
+(= (getKnobDefault (mkASK $discKnob $perms)) (getKnobDefault $discKnob))
 
 ;; (: getDisallowedSpecs (-> DiscreteKnob (List DiscSpec)))
 ;; (: getDisallowedSpecs (-> LogicalSubtreeKnob (List DiscSpec)))
 ;; (: getDisallowedSpecs (-> StrategySubtreeKnob (List DiscSpec)))
+;; (: getDisallowedSpecs (-> ActionSubtreeKnob (List DiscSpec)))
 (= (getDisallowedSpecs (mkDiscKnob $multiplicity $current $default $disAll)) $disAll)
 (= (getDisallowedSpecs (mkDiscKnob $knob $multiplicity $current $default $disAll)) $disAll)
 (= (getDisallowedSpecs (mkLSK $discKnob )) (getDisallowedSpecs $discKnob))
 (= (getDisallowedSpecs (mkSSK $discKnob )) (getDisallowedSpecs $discKnob))
+(= (getDisallowedSpecs (mkASK $discKnob $perms)) (getDisallowedSpecs $discKnob))
 
 (= (countNonDefaultDisallowed (mkDiscSpec $default) ()) 0)
 (= (countNonDefaultDisallowed (mkDiscSpec $default) (cons (mkDiscSpec $setting) $tail))
@@ -98,20 +110,25 @@
 ;; (: getKnobMultip (-> DiscreteKnob Multiplicity))
 ;; (: getKnobMultip (-> LogicalSubtreeKnob Multiplicity))
 ;; (: getKnobMultip (-> StrategySubtreeKnob Multiplicity))
+;; (: getKnobMultip (-> ActionSubtreeKnob Multiplicity))
 (= (getKnobMultip (mkDiscKnob (mkMultip $multiplicity) $current $default $disAll))
    (mkMultip (- $multiplicity (countNonDefaultDisallowed $default $disAll))))
 (= (getKnobMultip (mkDiscKnob $knob (mkMultip $multiplicity) $current $default $disAll))
    (mkMultip (- $multiplicity (countNonDefaultDisallowed $default $disAll))))
 (= (getKnobMultip (mkLSK $discKnob )) (getKnobMultip $discKnob))
 (= (getKnobMultip (mkSSK $discKnob )) (getKnobMultip $discKnob))
+(= (getKnobMultip (mkASK $discKnob $perms)) (getKnobMultip $discKnob))
 
-;; Calculates the knob Specification of an LSK or SSK
+;; Calculates the knob Specification of an LSK, SSK, or ASK
 ;; (: getKnobSpec (-> LogicalSubtreeKnob DiscSpec))
 ;; (: getKnobSpec (-> StrategySubtreeKnob DiscSpec))
+;; (: getKnobSpec (-> ActionSubtreeKnob DiscSpec))
 (= (getKnobSpec (mkLSK $discKnob))
    (let (mkMultip $multip) (getKnobMultip (mkLSK $discKnob)) (mkDiscSpec $multip)))
 (= (getKnobSpec (mkSSK $discKnob))
    (let (mkMultip $multip) (getKnobMultip (mkSSK $discKnob)) (mkDiscSpec $multip)))
+(= (getKnobSpec (mkASK $discKnob $perms))
+   (let (mkMultip $multip) (getKnobMultip (mkASK $discKnob $perms)) (mkDiscSpec $multip)))
 
 (= (allDisallowed $knob)
    (let (mkMultip $effectiveMultip) (getKnobMultip $knob)
@@ -155,9 +172,11 @@
 ;; (: getKnobLoc (-> DiscreteKnob (NodeId)))
 ;; (: getKnobLoc (-> LogicalSubtreeKnob (NodeId)))
 ;; (: getKnobLoc (-> StrategySubtreeKnob (NodeId)))
+;; (: getKnobLoc (-> ActionSubtreeKnob (NodeId)))
 (= (getKnobLoc (mkDiscKnob (mkKnob $loc) $multip $curr $def $dis)) $loc)
 (= (getKnobLoc (mkLSK $discKnob )) (getKnobLoc $discKnob))
 (= (getKnobLoc (mkSSK $discKnob )) (getKnobLoc $discKnob))
+(= (getKnobLoc (mkASK $discKnob $perms)) (getKnobLoc $discKnob))
 
 ;; A comparison function for discSpec 
 ;; (used as a $compFunc to insert knobSpec and knob pairs into a multimap ) 

--- a/representation/logical-probe.metta
+++ b/representation/logical-probe.metta
@@ -96,8 +96,34 @@
       ($temp (incrementState &knobCount (size-atom $index)))
       ;; Same embed-LSK design as the fast clause above.
       ($updatedKnobChildren (zipWith3 knobId $updatedChildren $newLskPair $index))
+	     )
+	     ($newLskPair (mkTree $node (append (subtraction-atom $children $updatedChildren) $updatedKnobChildren)))))
+
+;; Action probe builds one ASK containing all supplied action permutations.
+;; It intentionally skips disc probing, matching the original action path.
+(= (actionProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar $knobs)
+   (if (== $perms ())
+       ($knobs $exemplar)
+       (let*
+         (
+           (($updatedTree $ask) (actionSubtreeKnob $exemplar (mkNodeId $targetId) $perms))
+           ($discKnob (getDiscKnob $ask))
+         )
+         (if (or $addIfInExemplar (not (inExemplar $discKnob)))
+             (let $updatedKnobs (concatT $knobs ($ask))
+               ($updatedKnobs $updatedTree))
+             ($knobs $exemplar)))))
+
+(= (simpleActionProbe $exemplar (mkNodeId $targetId) $action $addIfInExemplar $knobs)
+   (let*
+     (
+       (($updatedTree $ask) (simpleActionSubtreeKnob $exemplar (mkNodeId $targetId)))
+       ($discKnob (getDiscKnob $ask))
      )
-     ($newLskPair (mkTree $node (append (subtraction-atom $children $updatedChildren) $updatedKnobChildren)))))
+     (if (or $addIfInExemplar (not (inExemplar $discKnob)))
+         (let $updatedKnobs (concatT $knobs ($ask))
+           ($updatedKnobs $updatedTree))
+         ($knobs $exemplar))))
 
 ;; Game-specific probe that uses strategySubtreeKnob instead of logicalSubtreeKnob
 ;; strategyProbe -> builds SSKs by processing game move permutations

--- a/representation/logical-probe.metta
+++ b/representation/logical-probe.metta
@@ -114,7 +114,7 @@
                ($updatedKnobs $updatedTree))
              ($knobs $exemplar)))))
 
-(= (simpleActionProbe $exemplar (mkNodeId $targetId) $action $addIfInExemplar $knobs)
+(= (simpleActionProbe $exemplar (mkNodeId $targetId) $addIfInExemplar $knobs)
    (let*
      (
        (($updatedTree $ask) (simpleActionSubtreeKnob $exemplar (mkNodeId $targetId)))

--- a/representation/logical-probe.metta
+++ b/representation/logical-probe.metta
@@ -102,26 +102,41 @@
 ;; Action probe builds one ASK containing all supplied action permutations.
 ;; It intentionally skips disc probing, matching the original action path.
 (= (actionProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar $knobs)
+   (actionProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar $knobs 0))
+
+(= (actionProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar $knobs $idx)
    (if (== $perms ())
        ($knobs $exemplar)
        (let*
          (
-           (($updatedTree $ask) (actionSubtreeKnob $exemplar (mkNodeId $targetId) $perms))
+           (($controlledSubtree $ask) (actionSubtreeKnob $perms))
            ($discKnob (getDiscKnob $ask))
          )
          (if (or $addIfInExemplar (not (inExemplar $discKnob)))
-             (let $updatedKnobs (concatT $knobs ($ask))
+             (let*
+               (
+                 (($updatedTree $_) (appendChild $exemplar (mkNodeId $targetId) (mkKnob $controlledSubtree $ask $idx)))
+                 ($updatedKnobs (concatT $knobs ($ask)))
+               )
                ($updatedKnobs $updatedTree))
              ($knobs $exemplar)))))
 
 (= (simpleActionProbe $exemplar (mkNodeId $targetId) $addIfInExemplar $knobs)
+   (simpleActionProbe $exemplar (mkNodeId $targetId) $addIfInExemplar $knobs 0))
+
+(= (simpleActionProbe $exemplar (mkNodeId $targetId) $addIfInExemplar $knobs $idx)
    (let*
      (
-       (($updatedTree $ask) (simpleActionSubtreeKnob $exemplar (mkNodeId $targetId)))
+       ($targetSubtree (getNodeById $exemplar (mkNodeId $targetId)))
+       (($controlledSubtree $ask) (simpleActionSubtreeKnob $targetSubtree))
        ($discKnob (getDiscKnob $ask))
      )
      (if (or $addIfInExemplar (not (inExemplar $discKnob)))
-         (let $updatedKnobs (concatT $knobs ($ask))
+         (let*
+           (
+             ($updatedTree (replaceNodeById $exemplar (mkNodeId $targetId) (mkKnob $controlledSubtree $ask $idx)))
+             ($updatedKnobs (concatT $knobs ($ask)))
+           )
            ($updatedKnobs $updatedTree))
          ($knobs $exemplar))))
 

--- a/representation/lsk.metta
+++ b/representation/lsk.metta
@@ -82,28 +82,82 @@
    )
 )
 
+;; Action subtree knobs store all selectable action permutations in the knob.
+;; The two-argument form follows the current embedded-knob representation.
+(= (actionSubtreeKnob $perms)
+   ((mkNullVex $perms)
+    (mkASK (mkDiscKnob (mkMultip (+ (length $perms) 1))
+                       (mkDiscSpec 0)
+                       (mkDiscSpec 0)
+                       ())
+           $perms)))
+
+(= (simpleActionSubtreeKnob $subtree)
+   ($subtree
+    (mkASK (mkDiscKnob (mkMultip 2)
+                       (mkDiscSpec 1)
+                       (mkDiscSpec 1)
+                       ())
+           (cons $subtree ()))))
+
+;; Compatibility form for node-id based callers.
+(= (actionSubtreeKnob $tree (mkNodeId $target) $perms)
+   (let*
+     (
+       (($nullVexTree $nullVexId) (appendChild $tree (mkNodeId $target) (mkNullVex ())))
+       ($multip (+ (length $perms) 1))
+     )
+     ($nullVexTree
+      (mkASK (mkDiscKnob (mkKnob (updateID $nullVexId))
+                         (mkMultip $multip)
+                         (mkDiscSpec 0)
+                         (mkDiscSpec 0)
+                         ())
+             $perms))))
+
+(= (simpleActionSubtreeKnob $tree (mkNodeId $target))
+   (let $subtree (getNodeById $tree (mkNodeId $target))
+     ($tree
+      (mkASK (mkDiscKnob (mkKnob (updateID (mkNodeId $target)))
+                         (mkMultip 2)
+                         (mkDiscSpec 1)
+                         (mkDiscSpec 1)
+                         ())
+             (cons $subtree ())))))
 
 ;; Retrieves the node ID from a Logical Subtree Knob (LSK) or Strategy Subtree Knob (SSK).
 ;; (: getNodeId (-> LogicalSubtreeKnob NodeId))
 ;; (: getNodeId (-> StrategySubtreeKnob NodeId))
+;; (: getNodeId (-> ActionSubtreeKnob NodeId))
 (= (getNodeId (mkLSK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList)))
    $nodeId)
 (= (getNodeId (mkSSK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList)))
    $nodeId)
+(= (getNodeId (mkASK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList) $perms))
+   $nodeId)
 
-;; Retrieves the current and default disc specifications from an LSK.
+;; Retrieves the current and default disc specifications from an LSK, SSK, or ASK.
 ;; (:getDiscSpec (-> LogicalSubtreeKnob (DiscSpec DiscSpec)))
+;; (:getDiscSpec (-> StrategySubtreeKnob (DiscSpec DiscSpec)))
+;; (:getDiscSpec (-> ActionSubtreeKnob (DiscSpec DiscSpec)))
 (= (getDiscSpec (mkLSK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList)))
+    (let ((mkDiscSpec $def) (mkDiscSpec $cur)) ($default $current) ($def $cur)))
+(= (getDiscSpec (mkSSK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList)))
+    (let ((mkDiscSpec $def) (mkDiscSpec $cur)) ($default $current) ($def $cur)))
+(= (getDiscSpec (mkASK (mkDiscKnob (mkKnob $nodeId) $multi $default $current $discSpecList) $perms))
     (let ((mkDiscSpec $def) (mkDiscSpec $cur)) ($default $current) ($def $cur)))
 
 
 ;; appendTo dispatcher - calls the appropriate function based on knob type
 ;; (: appendTo (-> (Tree $a) LogicalSubtreeKnob (Tree $a) NodeId Number (Tree $a)))
 ;; (: appendTo (-> (Tree $a) StrategySubtreeKnob (Tree $a) NodeId Number (Tree $a)))
+;; (: appendTo (-> (Tree $a) ActionSubtreeKnob (Tree $a) NodeId Number (Tree $a)))
 (= (appendTo $updatedTree (mkLSK $discKnob) $tree $parentId $d)
     (appendToLSK $updatedTree (mkLSK $discKnob) $tree $parentId $d))
 (= (appendTo $updatedTree (mkSSK $discKnob) $tree $parentId $d)
     (appendToSSK $updatedTree (mkSSK $discKnob) $tree $parentId $d))
+(= (appendTo $updatedTree (mkASK $discKnob $perms) $tree $parentId $d)
+    (appendToASK $updatedTree (mkASK $discKnob $perms) $tree $parentId $d))
 
     
 ;; Appends a subtree or a null vertex in place of a logical subtree 
@@ -191,6 +245,42 @@
                                   (0  ((mkNullVex (cons $subtree ())) $parentId)))) ;; If absent
 
                             (if (isNullVertex $treeToAppend)
-                                ($tree $parentId $parentId)
-                                (chain (appendChild $tree $parentId $treeToAppend) $treeChIdPair
-                                        ((first $treeChIdPair) $newSrcId (if (== $parentId $newDstId) (second $treeChIdPair) $newDstId))))))))
+	                                ($tree $parentId $parentId)
+	                                (chain (appendChild $tree $parentId $treeToAppend) $treeChIdPair
+	                                        ((first $treeChIdPair) $newSrcId (if (== $parentId $newDstId) (second $treeChIdPair) $newDstId))))))))
+
+(= (actionTargetSubtree (mkNullVex ()) (mkNodeId $targetId))
+   ((mkNullVex ()) (mkNodeId $targetId)))
+(= (actionTargetSubtree (mkNullVex (cons $child ())) (mkNodeId $targetId))
+   ($child (mkNodeId (union-atom $targetId (1)))))
+(= (actionTargetSubtree $targetTree (mkNodeId $targetId))
+   ($targetTree (mkNodeId $targetId)))
+
+;; appendTo for Action Subtree Knobs (ASK).
+;; Setting 0 removes the controlled action subtree; settings 1..N choose perms.
+(= (appendToASK $updatedTree $ask $tree $parentId $d)
+    (let*
+       (
+        ((mkNodeId $targetId) (getNodeId $ask))
+        ((mkNodeId $dstId) (if (= (mkNodeId (0)) $parentId) (mkNodeId ()) $parentId))
+        ($targetTree (getNodeById $updatedTree (mkNodeId $targetId)))
+        ($newPosition (+ (List.length (getChildren (getNodeById $tree $parentId))) 1))
+        (($subtree $newSrcId) (actionTargetSubtree $targetTree (mkNodeId $targetId)))
+        ((mkMultip $effectiveMultip) (getKnobMultip $ask))
+        ((mkDiscSpec $defaultSetting) (getKnobDefault $ask))
+        ((mkASK $discKnob $perms) $ask)
+       )
+      (if (>= $d $effectiveMultip)
+          (Error $d "Invalid effective disc specification for action knob.")
+          (let $actualD (mapEffectiveDiscSpec $ask $d)
+            (let ($treeToAppend $newDstId)
+                 (if (== $actualD 0)
+                     ((mkNullVex (cons $subtree ())) $parentId)
+                     (let $expressionToAppend (List.getByIdx $perms (- $actualD 1))
+                          ($expressionToAppend (mkNodeId (union-atom $dstId ($newPosition))))))
+                 (if (isNullVertex $treeToAppend)
+                     ($tree $parentId $parentId)
+                     (chain (appendChild $tree $parentId $treeToAppend) $treeChIdPair
+                            ((first $treeChIdPair)
+                             (if (== $defaultSetting 1) $newSrcId (second $treeChIdPair))
+                             (if (== $parentId $newDstId) (second $treeChIdPair) $newDstId)))))))))

--- a/representation/lsk.metta
+++ b/representation/lsk.metta
@@ -249,23 +249,18 @@
 	                                (chain (appendChild $tree $parentId $treeToAppend) $treeChIdPair
 	                                        ((first $treeChIdPair) $newSrcId (if (== $parentId $newDstId) (second $treeChIdPair) $newDstId))))))))
 
-(= (actionTargetSubtree (mkNullVex ()) (mkNodeId $targetId))
-   ((mkNullVex ()) (mkNodeId $targetId)))
-(= (actionTargetSubtree (mkNullVex (cons $child ())) (mkNodeId $targetId))
-   ($child (mkNodeId (union-atom $targetId (1)))))
-(= (actionTargetSubtree $targetTree (mkNodeId $targetId))
-   ($targetTree (mkNodeId $targetId)))
-
-;; appendTo for Action Subtree Knobs (ASK).
-;; Setting 0 removes the controlled action subtree; settings 1..N choose perms.
+;;;; ---------------------------------------------------------------------------
+;; appendToASK appends a permutation subtree for an Action Subtree Knob.
+;;
+;; default 0: action-subtree ASK, append selected perm and stop recursion.
+;; default 1: simple-action ASK, append existing subtree and recurse.
+;; Returns ($updatedTree $newSrcId $newDstId).
+;; ---------------------------------------------------------------------------
 (= (appendToASK $updatedTree $ask $tree $parentId $d)
     (let*
        (
         ((mkNodeId $targetId) (getNodeId $ask))
         ((mkNodeId $dstId) (if (= (mkNodeId (0)) $parentId) (mkNodeId ()) $parentId))
-        ($targetTree (getNodeById $updatedTree (mkNodeId $targetId)))
-        ($newPosition (+ (List.length (getChildren (getNodeById $tree $parentId))) 1))
-        (($subtree $newSrcId) (actionTargetSubtree $targetTree (mkNodeId $targetId)))
         ((mkMultip $effectiveMultip) (getKnobMultip $ask))
         ((mkDiscSpec $defaultSetting) (getKnobDefault $ask))
         ((mkASK $discKnob $perms) $ask)
@@ -273,14 +268,10 @@
       (if (>= $d $effectiveMultip)
           (Error $d "Invalid effective disc specification for action knob.")
           (let $actualD (mapEffectiveDiscSpec $ask $d)
-            (let ($treeToAppend $newDstId)
-                 (if (== $actualD 0)
-                     ((mkNullVex (cons $subtree ())) $parentId)
-                     (let $expressionToAppend (List.getByIdx $perms (- $actualD 1))
-                          ($expressionToAppend (mkNodeId (union-atom $dstId ($newPosition))))))
-                 (if (isNullVertex $treeToAppend)
-                     ($tree $parentId $parentId)
-                     (chain (appendChild $tree $parentId $treeToAppend) $treeChIdPair
-                            ((first $treeChIdPair)
-                             (if (== $defaultSetting 1) $newSrcId (second $treeChIdPair))
-                             (if (== $parentId $newDstId) (second $treeChIdPair) $newDstId)))))))))
+            (if (== $actualD 0)
+                ($tree $parentId $parentId)
+                (let $expressionToAppend (List.getByIdx $perms (- $actualD 1))
+                  (let $treeChIdPair (appendChild $tree $parentId $expressionToAppend)
+                    (if (== $defaultSetting 0)
+                        ((first $treeChIdPair) $parentId $parentId)
+                        ((first $treeChIdPair) (mkNodeId $targetId) (second $treeChIdPair))))))))))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -164,13 +164,6 @@
 ;; Helper function to extract tree from representation
 (= (getRepTree (mkRep $knobMapObj $tree)) $tree)
 
-;; Structural action operators are never domain actions.
-(= (isActionOperator $rootSymbol)
-   (is-member $rootSymbol (and_seq or_seq seq_exec action_not action_bool_if
-                           bool_action_if contin_action_if action_action_if
-                           action_success action_failure action_while
-                           bool_while return_success repeat_n)))
-
 ;; Universal getCandidate that works for both boolean and game strategies
 ;; Uses preOrder+buildTree to unwrap mkNullVex for games, cleanTree for boolean
 ;; (: getCandidate (-> Representation Instance (Tree $a)))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -164,12 +164,6 @@
 ;; Helper function to extract tree from representation
 (= (getRepTree (mkRep $knobMapObj $tree)) $tree)
 
-(= (isActionRootSymbol $rootSymbol)
-   (is-member $rootSymbol (and_seq or_seq seq_exec action_not action_bool_if
-                           bool_action_if contin_action_if action_action_if
-                           action_success action_failure action_while
-                           bool_while return_success repeat_n)))
-
 ;; Universal getCandidate that works for both boolean and game strategies
 ;; Uses preOrder+buildTree to unwrap mkNullVex for games, cleanTree for boolean
 ;; (: getCandidate (-> Representation Instance (Tree $a)))
@@ -191,13 +185,13 @@
                       ($rootNode (getNodeById (getRepTree $repObj) $srcid))
                       ($rootValue (getNodeValue $rootNode))
 	                      ($rootSymbol (if (== (get-metatype $rootValue) Expression)
-	                              (car-atom (cdr-atom $rootValue))
-	                              $rootValue))
-	                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
-	                      ($isActionDomain (isActionRootSymbol $rootSymbol))
-	                      ($finalTree (if (or $isGameStrategy $isActionDomain)
-	                                      (let* (
-	                                              ($expr (preOrder $candidate))
+		                              (car-atom (cdr-atom $rootValue))
+		                              $rootValue))
+		                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
+		                      ($isActionDomain (isActionOperator $rootSymbol))
+		                      ($finalTree (if (or $isGameStrategy $isActionDomain)
+		                                      (let* (
+		                                              ($expr (preOrder $candidate))
 	                                              ($cleanTree (buildTree $expr)))
                                             $cleanTree)
                                       (cleanTree $candidate)))
@@ -227,13 +221,13 @@
                       ($rootNode (getRepTree $repObj))
                       ($rootValue (getNodeValue $rootNode))
 	                      ($rootSymbol (if (== (get-metatype $rootValue) Expression)
-	                              (car-atom (cdr-atom $rootValue))
-	                              $rootValue))
-	                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
-	                      ($isActionDomain (isActionRootSymbol $rootSymbol))
-	                      ($finalTree (if (or $isGameStrategy $isActionDomain)
-	                                      (let* (
-	                                              ($expr (preOrder $candidate))
+		                              (car-atom (cdr-atom $rootValue))
+		                              $rootValue))
+		                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
+		                      ($isActionDomain (isActionOperator $rootSymbol))
+		                      ($finalTree (if (or $isGameStrategy $isActionDomain)
+		                                      (let* (
+		                                              ($expr (preOrder $candidate))
 	                                              ($cleanTree (buildTree $expr)))
                                             $cleanTree)
                                       (cleanTree $candidate)))
@@ -337,13 +331,17 @@
 (= (getCandidateHelper (mkInst $inst) (mkKnob $controlledSubtree (mkASK $discKnob $perms) $i))
    (let*
       (
-         ($setting (if (!= (getDisallowedSpecs (mkASK $discKnob $perms)) ())
-                     (mapEffectiveDiscSpec (mkASK $discKnob $perms) (index-atom $inst $i))
+         ($ask (mkASK $discKnob $perms))
+         ((mkDiscSpec $defaultSetting) (getKnobDefault $ask))
+         ($setting (if (!= (getDisallowedSpecs $ask) ())
+                     (mapEffectiveDiscSpec $ask (index-atom $inst $i))
                      (index-atom $inst $i)))
       )
       (if (== $setting 0)
          ()
-         (getCandidateHelper (mkInst $inst) (List.getByIdx $perms (- $setting 1))))))
+         (if (== $defaultSetting 0)
+             (getCandidateHelper (mkInst $inst) (List.getByIdx $perms (- $setting 1)))
+             (getCandidateHelper (mkInst $inst) $controlledSubtree)))))
 
 ;; Null-vertex unwrapping clause threads the embedded LSK to the inner knob.
 (= (getCandidateHelper $inst (mkKnob (mkNullVex ($child)) $lsk $i))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -164,6 +164,13 @@
 ;; Helper function to extract tree from representation
 (= (getRepTree (mkRep $knobMapObj $tree)) $tree)
 
+;; Structural action operators are never domain actions.
+(= (isActionOperator $rootSymbol)
+   (is-member $rootSymbol (and_seq or_seq seq_exec action_not action_bool_if
+                           bool_action_if contin_action_if action_action_if
+                           action_success action_failure action_while
+                           bool_while return_success repeat_n)))
+
 ;; Universal getCandidate that works for both boolean and game strategies
 ;; Uses preOrder+buildTree to unwrap mkNullVex for games, cleanTree for boolean
 ;; (: getCandidate (-> Representation Instance (Tree $a)))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -126,11 +126,49 @@
                                     ;; ($_ (println! (updated tereeeeee dddddddddddd disc mappppp ($updatedTree $dscMp))))
                                     ;; ($_ (println! ""))
                                     ;; ($dscKbMp (crtDiscKnobMap (mkDscMp $dscMp) (mkDscKbMp ()) 0)))        ;; MULITPLE args selected using the feature selection
-                                    ($dscKbMp (mkDscMp $dscMp)))        ;; MULITPLE args selected using the feature selection
-                                 (mkRep (mkKbMap $dscKbMp) $updatedTree)))))
+	                                    ($dscKbMp (mkDscMp $dscMp)))        ;; MULITPLE args selected using the feature selection
+	                                 (mkRep (mkKbMap $dscKbMp) $updatedTree)))))
+
+(= (representation
+            $nDeme
+            $exemplar
+            (mkITable $table $labels)
+            $ft-selection-algo
+            $prune-exemplar
+            $enforced-fts
+            $scorerType
+            $actions
+            $perceptions
+         )
+         (representation $nDeme $exemplar (mkITable $table $labels) $ft-selection-algo $prune-exemplar $enforced-fts $scorerType True $actions $perceptions))
+
+(= (representation
+            $nDeme
+            $exemplar
+            (mkITable $table $labels)
+            $ft-selection-algo
+            $prune-exemplar
+            $enforced-fts
+            $scorerType
+            $disable-discprobe
+            $actions
+            $perceptions
+         )
+         (let* (
+                  (($updatedTree $dscMp) (buildKnobs $exemplar () () $actions $perceptions))
+                  ($_ (resetState &knobCount))
+                  ($dscKbMp (mkDscMp $dscMp))
+               )
+               ((mkRep (mkKbMap $dscKbMp) $updatedTree))))
 
 ;; Helper function to extract tree from representation
 (= (getRepTree (mkRep $knobMapObj $tree)) $tree)
+
+(= (isActionRootSymbol $rootSymbol)
+   (is-member $rootSymbol (and_seq or_seq seq_exec action_not action_bool_if
+                           bool_action_if contin_action_if action_action_if
+                           action_success action_failure action_while
+                           bool_while return_success repeat_n)))
 
 ;; Universal getCandidate that works for both boolean and game strategies
 ;; Uses preOrder+buildTree to unwrap mkNullVex for games, cleanTree for boolean
@@ -152,14 +190,15 @@
                       ;; ($_ (println! (Found candidate: (preOrder $candidate))))
                       ($rootNode (getNodeById (getRepTree $repObj) $srcid))
                       ($rootValue (getNodeValue $rootNode))
-                      ($rootSymbol (if (== (get-metatype $rootValue) Expression) 
-                              (car-atom (cdr-atom $rootValue))
-                              $rootValue))
-                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
-                      ($finalTree (if $isGameStrategy
-                                      (let* (
-                                              ($expr (preOrder $candidate))
-                                              ($cleanTree (buildTree $expr)))
+	                      ($rootSymbol (if (== (get-metatype $rootValue) Expression)
+	                              (car-atom (cdr-atom $rootValue))
+	                              $rootValue))
+	                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
+	                      ($isActionDomain (isActionRootSymbol $rootSymbol))
+	                      ($finalTree (if (or $isGameStrategy $isActionDomain)
+	                                      (let* (
+	                                              ($expr (preOrder $candidate))
+	                                              ($cleanTree (buildTree $expr)))
                                             $cleanTree)
                                       (cleanTree $candidate)))
 
@@ -187,14 +226,15 @@
                       ;; ($_ (println! (Found candidate: (preOrder $candidate))))
                       ($rootNode (getRepTree $repObj))
                       ($rootValue (getNodeValue $rootNode))
-                      ($rootSymbol (if (== (get-metatype $rootValue) Expression) 
-                              (car-atom (cdr-atom $rootValue))
-                              $rootValue))
-                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
-                      ($finalTree (if $isGameStrategy
-                                      (let* (
-                                              ($expr (preOrder $candidate))
-                                              ($cleanTree (buildTree $expr)))
+	                      ($rootSymbol (if (== (get-metatype $rootValue) Expression)
+	                              (car-atom (cdr-atom $rootValue))
+	                              $rootValue))
+	                      ($isGameStrategy (== $rootSymbol PRIORITIZED-OR))
+	                      ($isActionDomain (isActionRootSymbol $rootSymbol))
+	                      ($finalTree (if (or $isGameStrategy $isActionDomain)
+	                                      (let* (
+	                                              ($expr (preOrder $candidate))
+	                                              ($cleanTree (buildTree $expr)))
                                             $cleanTree)
                                       (cleanTree $candidate)))
 
@@ -293,6 +333,17 @@
 )
 
 ;; getCandidateRec (mkRep $knobMapObj $tree) (mkInst $inst)
+
+(= (getCandidateHelper (mkInst $inst) (mkKnob $controlledSubtree (mkASK $discKnob $perms) $i))
+   (let*
+      (
+         ($setting (if (!= (getDisallowedSpecs (mkASK $discKnob $perms)) ())
+                     (mapEffectiveDiscSpec (mkASK $discKnob $perms) (index-atom $inst $i))
+                     (index-atom $inst $i)))
+      )
+      (if (== $setting 0)
+         ()
+         (getCandidateHelper (mkInst $inst) (List.getByIdx $perms (- $setting 1))))))
 
 ;; Null-vertex unwrapping clause threads the embedded LSK to the inner knob.
 (= (getCandidateHelper $inst (mkKnob (mkNullVex ($child)) $lsk $i))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -343,9 +343,16 @@
              (getCandidateHelper (mkInst $inst) (List.getByIdx $perms (- $setting 1)))
              (getCandidateHelper (mkInst $inst) $controlledSubtree)))))
 
-;; Null-vertex unwrapping clause threads the embedded LSK to the inner knob.
-(= (getCandidateHelper $inst (mkKnob (mkNullVex ($child)) $lsk $i))
-   (getCandidateHelper $inst (mkKnob $child $lsk $i)))
+;; Null-vertex unwrapping for LSK and SSK knobs only.
+;; mkASK knobs are handled exclusively by the ASK rule above,
+;; which reads perms directly from the controlled NullVex.
+;; Keeping this generic caused double evaluation whenever the
+;; ASK rule (Rule A) and this unwrapping rule both fired on
+;; the same (mkKnob (mkNullVex ...) (mkASK ...) $i) expression.
+(= (getCandidateHelper $inst (mkKnob (mkNullVex ($child)) (mkLSK $discKnob) $i))
+   (getCandidateHelper $inst (mkKnob $child (mkLSK $discKnob) $i)))
+(= (getCandidateHelper $inst (mkKnob (mkNullVex ($child)) (mkSSK $discKnob) $i))
+   (getCandidateHelper $inst (mkKnob $child (mkSSK $discKnob) $i)))
 
 ;; Specialized fast clause: empty disallowed list means effective settings map
 ;; one-to-one to actual settings, so we skip mapEffectiveDiscSpec entirely.

--- a/representation/tests/build-action-test.metta
+++ b/representation/tests/build-action-test.metta
@@ -6,6 +6,7 @@
 !(import! &self ../../utilities/tree)
 
 !(import! &self ../../scoring/bscore)
+!(import! &self ../../scoring/cacheSpace)
 
 !(import! &self ../../representation/knob-representation)
 !(import! &self ../../representation/lsk)
@@ -30,10 +31,10 @@
 !(assertEqual (isActionOperator seq_exec) True)
 !(assertEqual (isActionOperator move_forward) False)
 
-!(assertEqual (isBuiltinAction move_forward (move_forward turn_left)) True)
-!(assertEqual (isBuiltinAction ahead_blocked (move_forward turn_left)) False)
-!(assertEqual (isBuiltinAction and_seq (move_forward turn_left)) False)
-!(assertEqual (isBuiltinAction action_bool_if (move_forward turn_left)) False)
+!(assertEqual (isDomainAction move_forward (move_forward turn_left)) True)
+!(assertEqual (isDomainAction ahead_blocked (move_forward turn_left)) False)
+!(assertEqual (isDomainAction and_seq (move_forward turn_left)) False)
+!(assertEqual (isDomainAction action_bool_if (move_forward turn_left)) False)
 
 ;; Action permutation sampling keeps the base action domain.
 !(assertEqual
@@ -121,16 +122,67 @@
 
 ;; Direct probes produce action knobs with the expected ASK defaults.
 !(assertEqual
-  (let ($tree $mmp) (addActionKnobsAt (mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0)) True () (move_forward turn_left) (A B))
-    (> (MultiMap.length $mmp) 0))
+  (let*
+    (
+      (($tree $mmp) (addActionKnobsAt (mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0)) True () (move_forward turn_left) ()))
+      ($ask (car-atom (MultiMap.values $mmp)))
+      ((mkASK $discKnob $perms) $ask)
+      ($embedded (getNodeById $tree (mkNodeId (1))))
+    )
+    (and (> (MultiMap.length $mmp) 0)
+         (and (== $discKnob (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))
+              (== $embedded (mkKnob (mkNullVex $perms) $ask 0)))))
   True)
 
 !(assertEqual
   (let* (($origTree (mkTree (mkNode and_seq) (cons (moveTree) ())))
          (($updatedTree $mmp) (addSimpleActionKnobsAt $origTree (mkNodeId (0)) (mkNodeId (1)) True () (move_forward turn_left) (A B)))
          ($ask (car-atom (MultiMap.values $mmp))))
-    ($updatedTree (getKnobDefault $ask)))
-  ((mkTree (mkNode and_seq) (cons (moveTree) ())) (mkDiscSpec 1)))
+    (let*
+      (
+        ((mkASK $discKnob $perms) $ask)
+        ($embedded (getNodeById $updatedTree (mkNodeId (1))))
+      )
+      (and (== $embedded (mkKnob (moveTree) $ask 0))
+           (and (== $discKnob (mkDiscKnob (mkMultip 2) (mkDiscSpec 1) (mkDiscSpec 1) ()))
+                (and (== $perms (cons (moveTree) ()))
+                     (== (getKnobDefault $ask) (mkDiscSpec 1)))))))
+  True)
+
+;; Embedded action representation drives candidate reconstruction directly.
+!(assertEqual
+  (let*
+    (
+      (($updatedTree $mmp) (addActionKnobsAt (mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0)) True () (move_forward turn_left) ()))
+      ($rep (mkRep (mkKbMap (mkDscMp $mmp)) $updatedTree))
+      ($absent (getCandidate $rep ActionCandidateAbsent (mkInst (0))))
+      ($move (getCandidate $rep ActionCandidateMove (mkInst (1))))
+      ($turn (getCandidate $rep ActionCandidateTurn (mkInst (2))))
+    )
+    ($absent $move $turn))
+  ((mkTree (mkNode and_seq) ())
+   (mkTree (mkNode and_seq) ((moveTree)))
+   (mkTree (mkNode and_seq) ((turnTree)))))
+
+;; Simple-action ASK present mode recurses into the embedded controlled subtree.
+!(assertEqual
+  (let*
+    (
+      (($actionControlled $actionAsk) (actionSubtreeKnob ((turnTree))))
+      (($simpleControlled $simpleAsk)
+        (simpleActionSubtreeKnob
+          (mkTree (mkNode and_seq)
+            ((mkKnob $actionControlled $actionAsk 1)))))
+      ($tree (mkTree (mkNode action_bool_if)
+               ((mkTree (mkNode A) ())
+                (mkKnob $simpleControlled $simpleAsk 0)
+                (moveTree))))
+    )
+    (getCandidateHelper (mkInst (1 1)) $tree))
+  (mkTree (mkNode action_bool_if)
+    ((mkTree (mkNode A) ())
+     (mkTree (mkNode and_seq) ((turnTree)))
+     (moveTree))))
 
 ;; action_bool_if keeps its perception child and wraps action branches.
 !(assertEqual
@@ -139,17 +191,24 @@
                      (cons (moveTree)
                      (cons (turnTree) ())))))
          (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
-         ($perception (getNodeById $updatedTree (mkNodeId (1))))
-         ($branchA (getNodeById $updatedTree (mkNodeId (2))))
-         ($branchB (getNodeById $updatedTree (mkNodeId (3)))))
+         ($perception (getNodeById $updatedTree (mkNodeId (1)))))
     (and (== $perception (mkTree (mkNode A) ()))
-         (and (== $branchA (mkTree (mkNode and_seq)
-                              (cons (moveTree)
-                              (cons (mkNullVex ()) ()))))
-         (and (== $branchB (mkTree (mkNode and_seq)
-                              (cons (turnTree)
-                              (cons (mkNullVex ()) ()))))
-              (== (MultiMap.length $mmp) 2)))))
+         (let*
+           (
+             ($askA (List.getByIdx (MultiMap.values $mmp) 0))
+             ($askB (List.getByIdx (MultiMap.values $mmp) 1))
+             ((mkASK $discA $permsA) $askA)
+             ((mkASK $discB $permsB) $askB)
+             ($branchAHead (getNodeById $updatedTree (mkNodeId (2 1))))
+             ($branchBHead (getNodeById $updatedTree (mkNodeId (3 1))))
+             ($branchAKnob (getNodeById $updatedTree (mkNodeId (2 2))))
+             ($branchBKnob (getNodeById $updatedTree (mkNodeId (3 2))))
+           )
+           (and (== $branchAHead (moveTree))
+                (and (== $branchBHead (turnTree))
+                     (and (== $branchAKnob (mkKnob (mkNullVex $permsA) $askA 0))
+                          (and (== $branchBKnob (mkKnob (mkNullVex $permsB) $askB 1))
+                               (== (MultiMap.length $mmp) 2))))))))
   True)
 
 ;; and_seq follows the C++ probabilistic path and produces knobs with this seed.

--- a/representation/tests/build-action-test.metta
+++ b/representation/tests/build-action-test.metta
@@ -165,15 +165,9 @@
     (> (MultiMap.length $mmp) 0))
   True)
 
-;; buildKnobs dispatches action, logical, and strategy roots correctly.
+;; buildKnobs dispatches action and strategy roots
 !(assertEqual
   (let ($updatedTree $mmp) (buildKnobs (mkTree (mkNode and_seq) (cons (moveTree) ())) () () (move_forward turn_left) (A B))
-    (> (MultiMap.length $mmp) 0))
-  True)
-
-!(assertEqual
-  (let* (($tree (mkTree (mkNode OR) (cons (mkTree (mkNode A) ()) ())))
-         (($updatedTree $mmp) (buildKnobs $tree () (A B) (move_forward turn_left) (A B))))
     (> (MultiMap.length $mmp) 0))
   True)
 

--- a/representation/tests/build-action-test.metta
+++ b/representation/tests/build-action-test.metta
@@ -1,0 +1,177 @@
+!(import! &self ../../utilities/general-helpers)
+!(import! &self ../../utilities/list-methods)
+!(import! &self ../../utilities/ordered-multimap)
+!(import! &self ../../utilities/lazy-random-selector)
+!(import! &self ../../utilities/nodeId)
+!(import! &self ../../utilities/tree)
+
+!(import! &self ../../scoring/bscore)
+
+!(import! &self ../../representation/knob-representation)
+!(import! &self ../../representation/lsk)
+!(import! &self ../../representation/logical-probe)
+!(import! &self ../../representation/sample-logical-perms)
+!(import! &self ../../representation/add-logical-knobs)
+!(import! &self ../../representation/build-logical)
+!(import! &self ../../representation/logical-canonize)
+!(import! &self ../../representation/build-action)
+!(import! &self ../../representation/build-knobs)
+!(import! &self ../../representation/representation)
+
+!(py-call (random.seed 12))
+
+(= (moveTree) (mkTree (mkNode move_forward) ()))
+(= (turnTree) (mkTree (mkNode turn_left) ()))
+(= (actionPerms) ((moveTree) (turnTree)))
+
+!(assertEqual (isActionOperator and_seq) True)
+!(assertEqual (isActionOperator action_bool_if) True)
+!(assertEqual (isActionOperator seq_exec) True)
+!(assertEqual (isActionOperator move_forward) False)
+
+!(assertEqual (isBuiltinAction move_forward) True)
+!(assertEqual (isBuiltinAction and_seq) False)
+!(assertEqual (isBuiltinAction move_forward (move_forward turn_left)) True)
+!(assertEqual (isBuiltinAction ahead_blocked (move_forward turn_left)) False)
+
+!(assertEqual
+  (let $perms (sampleActionPerms (move_forward turn_left) (A B))
+    (and (is-member move_forward $perms)
+         (is-member turn_left $perms)))
+  True)
+
+!(assertEqual
+  (sampleActionPerms (move_forward) (A B))
+  (move_forward))
+
+!(assertEqual
+  (sampleActionPerms (move_forward turn_left) ())
+  (move_forward turn_left))
+
+!(assertEqual
+  (let ($controlled $ask) (actionSubtreeKnob (actionPerms))
+    ((getRawKnobMultip $ask) (getKnobDefault $ask)))
+  ((mkMultip 3) (mkDiscSpec 0)))
+
+!(assertEqual
+  (let ($controlled $ask) (simpleActionSubtreeKnob (moveTree))
+    ((getRawKnobMultip $ask) (getKnobDefault $ask)))
+  ((mkMultip 2) (mkDiscSpec 1)))
+
+!(assertEqual
+  (getCandidateHelper
+    (mkInst (0))
+    (mkTree (mkNode and_seq)
+      ((mkKnob (mkNullVex (actionPerms))
+               (mkASK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) (actionPerms))
+               0))))
+  (mkTree (mkNode and_seq) ()))
+
+!(assertEqual
+  (getCandidateHelper
+    (mkInst (1))
+    (mkTree (mkNode and_seq)
+      ((mkKnob (mkNullVex (actionPerms))
+               (mkASK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) (actionPerms))
+               0))))
+  (mkTree (mkNode and_seq) ((moveTree))))
+
+!(assertEqual
+  (getCandidateHelper
+    (mkInst (2))
+    (mkTree (mkNode and_seq)
+      ((mkKnob (mkNullVex (actionPerms))
+               (mkASK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) (actionPerms))
+               0))))
+  (mkTree (mkNode and_seq) ((turnTree))))
+
+!(assertEqual
+  (let* (
+    ($origTree (mkTree (mkNode and_seq) ((moveTree))))
+    (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
+  )
+    (and (> (MultiMap.length $mmp) 0)
+         (not (== $updatedTree $origTree))))
+  True)
+
+!(assertEqual
+  (let* (
+    ($origTree (mkTree (mkNode action_bool_if) ((mkTree (mkNode A) ()) (moveTree) (turnTree))))
+    (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
+  )
+    (>= (MultiMap.length $mmp) 0))
+  True)
+
+!(assertEqual
+  (let ($updatedTree $mmp) (buildAction (mkTree (mkNode and_seq) ()) (mkNodeId (0)) () (move_forward turn_left) (A B))
+    (> (MultiMap.length $mmp) 0))
+  True)
+
+!(assertEqual
+  (let ($updatedTree $mmp) (buildKnobs (mkTree (mkNode and_seq) ((moveTree))) () () (move_forward turn_left) (A B))
+    (> (MultiMap.length $mmp) 0))
+  True)
+
+!(assertEqual
+  (let* (
+    ($reps (representation
+             3
+             (mkTree (mkNode and_seq) ((moveTree)))
+             (mkITable ((true true) (false false)) (A Output))
+             hc
+             False
+             ()
+             mi
+             (move_forward turn_left)
+             (A)))
+    ((mkRep (mkKbMap (mkDscMp $mmp)) $tree) (car-atom $reps))
+  )
+    (and (== (length $reps) 1)
+         (and (> (MultiMap.length $mmp) 0)
+         (not (== $tree (mkTree (mkNode and_seq) ((moveTree)))))))
+  )
+  True)
+
+!(assertEqual
+  (let* (
+    ($tree (mkTree (mkNode OR) ((mkTree (mkNode A) ()))))
+    (($updatedTree $mmp) (buildKnobs $tree () (A B) (move_forward turn_left) (A B)))
+  )
+    (> (MultiMap.length $mmp) 0))
+  True)
+
+!(assertEqual
+  (let* (
+    ($tree (mkTree (mkNode PRIORITIZED-OR) ((mkTree (mkNode playcenter) ()) (mkTree (mkNode playcorner) ()) (mkTree (mkNode playblock) ()))))
+    (($updatedTree $mmp) (buildKnobs $tree () (playcenter playcorner playblock) () ()))
+  )
+    (> (MultiMap.length $mmp) 0))
+  True)
+
+!(assertEqual
+  (actionCanonize (mkTree (mkNode and_seq) ((moveTree))))
+  (mkTree (mkNode and_seq) ((moveTree))))
+
+!(assertEqual
+  (actionCanonize (moveTree))
+  (mkTree (mkNode and_seq) ((moveTree))))
+
+!(assertEqual
+  (actionCleanup (mkTree (mkNode and_seq) ()))
+  (mkNullVex ()))
+
+!(assertEqual
+  (actionCleanup (mkTree (mkNode or_seq) ()))
+  (mkNullVex ()))
+
+!(assertEqual
+  (actionCleanup (mkTree (mkNode seq_exec) ()))
+  (mkNullVex ()))
+
+!(assertEqual
+  (actionCleanup (mkTree (mkNode action_failure) ()))
+  (mkTree (mkNode action_failure) ()))
+
+!(assertEqual
+  (actionCleanup (mkTree (mkNode and_seq) ((moveTree))))
+  (mkTree (mkNode and_seq) ((moveTree))))

--- a/representation/tests/build-action-test.metta
+++ b/representation/tests/build-action-test.metta
@@ -24,16 +24,18 @@
 (= (turnTree) (mkTree (mkNode turn_left) ()))
 (= (actionPerms) ((moveTree) (turnTree)))
 
+;; Structural action operators are classified separately from domain actions.
 !(assertEqual (isActionOperator and_seq) True)
 !(assertEqual (isActionOperator action_bool_if) True)
 !(assertEqual (isActionOperator seq_exec) True)
 !(assertEqual (isActionOperator move_forward) False)
 
-!(assertEqual (isBuiltinAction move_forward) True)
-!(assertEqual (isBuiltinAction and_seq) False)
 !(assertEqual (isBuiltinAction move_forward (move_forward turn_left)) True)
 !(assertEqual (isBuiltinAction ahead_blocked (move_forward turn_left)) False)
+!(assertEqual (isBuiltinAction and_seq (move_forward turn_left)) False)
+!(assertEqual (isBuiltinAction action_bool_if (move_forward turn_left)) False)
 
+;; Action permutation sampling keeps the base action domain.
 !(assertEqual
   (let $perms (sampleActionPerms (move_forward turn_left) (A B))
     (and (is-member move_forward $perms)
@@ -48,6 +50,7 @@
   (sampleActionPerms (move_forward turn_left) ())
   (move_forward turn_left))
 
+;; Embedded ASK constructors retain their defaults.
 !(assertEqual
   (let ($controlled $ask) (actionSubtreeKnob (actionPerms))
     ((getRawKnobMultip $ask) (getKnobDefault $ask)))
@@ -58,6 +61,7 @@
     ((getRawKnobMultip $ask) (getKnobDefault $ask)))
   ((mkMultip 2) (mkDiscSpec 1)))
 
+;; Embedded ASK candidate reconstruction still maps 0 to absent, 1..N to perms.
 !(assertEqual
   (getCandidateHelper
     (mkInst (0))
@@ -85,21 +89,75 @@
                0))))
   (mkTree (mkNode and_seq) ((turnTree))))
 
+;; Simple-action ASK preserves recursive candidate expansion into the subtree.
 !(assertEqual
-  (let* (
-    ($origTree (mkTree (mkNode and_seq) ((moveTree))))
-    (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
-  )
-    (and (> (MultiMap.length $mmp) 0)
-         (not (== $updatedTree $origTree))))
+  (let* (($origTree (mkTree (mkNode and_seq) (cons (moveTree) ())))
+         (($updatedTree $ask) (simpleActionSubtreeKnob $origTree (mkNodeId (1))))
+         (($candidate $srcId $dstId) (appendToASK $updatedTree $ask (mkTree (mkNode and_seq) ()) (mkNodeId (0)) 1)))
+    ($candidate $srcId $dstId))
+  ((mkTree (mkNode and_seq) (cons (moveTree) ())) (mkNodeId (1)) (mkNodeId (1))))
+
+!(assertEqual
+  (let* (($origTree (mkTree (mkNode and_seq) (cons (moveTree) ())))
+         (($updatedTree $ask) (simpleActionSubtreeKnob $origTree (mkNodeId (1))))
+         (($candidate $srcId $dstId) (appendToASK $updatedTree $ask (mkTree (mkNode and_seq) ()) (mkNodeId (0)) 0)))
+    ($candidate $srcId $dstId))
+  ((mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0))))
+
+;; Action-subtree ASK appends selected perms but stops recursive expansion.
+!(assertEqual
+  (let* (($origTree (mkTree (mkNode and_seq) ()))
+         (($updatedTree $ask) (actionSubtreeKnob $origTree (mkNodeId (0)) ((moveTree))))
+         (($candidate $srcId $dstId) (appendToASK $updatedTree $ask (mkTree (mkNode and_seq) ()) (mkNodeId (0)) 1)))
+    ($candidate $srcId $dstId))
+  ((mkTree (mkNode and_seq) (cons (moveTree) ())) (mkNodeId (0)) (mkNodeId (0))))
+
+!(assertEqual
+  (let* (($origTree (mkTree (mkNode and_seq) ()))
+         (($updatedTree $ask) (actionSubtreeKnob $origTree (mkNodeId (0)) ((moveTree))))
+         (($candidate $srcId $dstId) (appendToASK $updatedTree $ask (mkTree (mkNode and_seq) ()) (mkNodeId (0)) 0)))
+    ($candidate $srcId $dstId))
+  ((mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0))))
+
+;; Direct probes produce action knobs with the expected ASK defaults.
+!(assertEqual
+  (let ($tree $mmp) (addActionKnobsAt (mkTree (mkNode and_seq) ()) (mkNodeId (0)) (mkNodeId (0)) True () (move_forward turn_left) (A B))
+    (> (MultiMap.length $mmp) 0))
   True)
 
 !(assertEqual
-  (let* (
-    ($origTree (mkTree (mkNode action_bool_if) ((mkTree (mkNode A) ()) (moveTree) (turnTree))))
-    (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
-  )
-    (>= (MultiMap.length $mmp) 0))
+  (let* (($origTree (mkTree (mkNode and_seq) (cons (moveTree) ())))
+         (($updatedTree $mmp) (addSimpleActionKnobsAt $origTree (mkNodeId (0)) (mkNodeId (1)) True () (move_forward turn_left) (A B)))
+         ($ask (car-atom (MultiMap.values $mmp))))
+    ($updatedTree (getKnobDefault $ask)))
+  ((mkTree (mkNode and_seq) (cons (moveTree) ())) (mkDiscSpec 1)))
+
+;; action_bool_if keeps its perception child and wraps action branches.
+!(assertEqual
+  (let* (($origTree (mkTree (mkNode action_bool_if)
+                     (cons (mkTree (mkNode A) ())
+                     (cons (moveTree)
+                     (cons (turnTree) ())))))
+         (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B)))
+         ($perception (getNodeById $updatedTree (mkNodeId (1))))
+         ($branchA (getNodeById $updatedTree (mkNodeId (2))))
+         ($branchB (getNodeById $updatedTree (mkNodeId (3)))))
+    (and (== $perception (mkTree (mkNode A) ()))
+         (and (== $branchA (mkTree (mkNode and_seq)
+                              (cons (moveTree)
+                              (cons (mkNullVex ()) ()))))
+         (and (== $branchB (mkTree (mkNode and_seq)
+                              (cons (turnTree)
+                              (cons (mkNullVex ()) ()))))
+              (== (MultiMap.length $mmp) 2)))))
+  True)
+
+;; and_seq follows the C++ probabilistic path and produces knobs with this seed.
+!(assertEqual
+  (let* (($origTree (mkTree (mkNode and_seq) (cons (moveTree) ())))
+         (($updatedTree $mmp) (buildAction $origTree (mkNodeId (0)) () (move_forward turn_left) (A B))))
+    (and (> (MultiMap.length $mmp) 0)
+         (not (== $updatedTree $origTree))))
   True)
 
 !(assertEqual
@@ -107,54 +165,35 @@
     (> (MultiMap.length $mmp) 0))
   True)
 
+;; buildKnobs dispatches action, logical, and strategy roots correctly.
 !(assertEqual
-  (let ($updatedTree $mmp) (buildKnobs (mkTree (mkNode and_seq) ((moveTree))) () () (move_forward turn_left) (A B))
+  (let ($updatedTree $mmp) (buildKnobs (mkTree (mkNode and_seq) (cons (moveTree) ())) () () (move_forward turn_left) (A B))
     (> (MultiMap.length $mmp) 0))
   True)
 
 !(assertEqual
-  (let* (
-    ($reps (representation
-             3
-             (mkTree (mkNode and_seq) ((moveTree)))
-             (mkITable ((true true) (false false)) (A Output))
-             hc
-             False
-             ()
-             mi
-             (move_forward turn_left)
-             (A)))
-    ((mkRep (mkKbMap (mkDscMp $mmp)) $tree) (car-atom $reps))
-  )
-    (and (== (length $reps) 1)
-         (and (> (MultiMap.length $mmp) 0)
-         (not (== $tree (mkTree (mkNode and_seq) ((moveTree)))))))
-  )
-  True)
-
-!(assertEqual
-  (let* (
-    ($tree (mkTree (mkNode OR) ((mkTree (mkNode A) ()))))
-    (($updatedTree $mmp) (buildKnobs $tree () (A B) (move_forward turn_left) (A B)))
-  )
+  (let* (($tree (mkTree (mkNode OR) (cons (mkTree (mkNode A) ()) ())))
+         (($updatedTree $mmp) (buildKnobs $tree () (A B) (move_forward turn_left) (A B))))
     (> (MultiMap.length $mmp) 0))
   True)
 
 !(assertEqual
-  (let* (
-    ($tree (mkTree (mkNode PRIORITIZED-OR) ((mkTree (mkNode playcenter) ()) (mkTree (mkNode playcorner) ()) (mkTree (mkNode playblock) ()))))
-    (($updatedTree $mmp) (buildKnobs $tree () (playcenter playcorner playblock) () ()))
-  )
+  (let* (($tree (mkTree (mkNode PRIORITIZED-OR)
+                  (cons (mkTree (mkNode playcenter) ())
+                  (cons (mkTree (mkNode playcorner) ())
+                  (cons (mkTree (mkNode playblock) ()) ())))))
+         (($updatedTree $mmp) (buildKnobs $tree () (playcenter playcorner playblock) () ())))
     (> (MultiMap.length $mmp) 0))
   True)
 
+;; Canonize and cleanup mirror the C++ action pre/post passes.
 !(assertEqual
-  (actionCanonize (mkTree (mkNode and_seq) ((moveTree))))
-  (mkTree (mkNode and_seq) ((moveTree))))
+  (actionCanonize (mkTree (mkNode and_seq) (cons (moveTree) ())))
+  (mkTree (mkNode and_seq) (cons (moveTree) ())))
 
 !(assertEqual
   (actionCanonize (moveTree))
-  (mkTree (mkNode and_seq) ((moveTree))))
+  (mkTree (mkNode and_seq) (cons (moveTree) ())))
 
 !(assertEqual
   (actionCleanup (mkTree (mkNode and_seq) ()))
@@ -173,5 +212,5 @@
   (mkTree (mkNode action_failure) ()))
 
 !(assertEqual
-  (actionCleanup (mkTree (mkNode and_seq) ((moveTree))))
-  (mkTree (mkNode and_seq) ((moveTree))))
+  (actionCleanup (mkTree (mkNode and_seq) (cons (moveTree) ())))
+  (mkTree (mkNode and_seq) (cons (moveTree) ())))

--- a/representation/tests/build-knobs-test.metta
+++ b/representation/tests/build-knobs-test.metta
@@ -14,70 +14,114 @@
 !(import! &self ../../representation/sample-logical-perms)
 !(import! &self ../../representation/add-logical-knobs)
 !(import! &self ../../representation/build-logical)
+!(import! &self ../../representation/build-action)
 !(import! &self ../../representation/build-knobs)
 
 !(py-call (random.seed 0))
 
+;; =============================================================================
+;; buildKnobs (3-arity / 4-arity) - logical path
+;; =============================================================================
+
+;; Minimal boolean exemplar used to verify logical knob decoration.
 (= (tree1) (mkTree (mkNode OR)
                         (cons (mkTree (mkNode C) ()) ())))
 
-;; Game strategy tree for testing PRIORITIZED-OR knob building
-(= (gameTree1) (mkTree (mkNode PRIORITIZED-OR)
-                      (cons (mkTree (mkNode playcenter) ())
-                      (cons (mkTree (mkNode playcorner) ()) ()))))
-
-;; buildKnobs should materially change the tree and produce many knobs
-!(assertEqual (let ($updatedTree $MMap) (buildKnobs (tree1) () (A B))
-                     (and (== $updatedTree 
-                              (mkTree (mkNode AND) ((mkTree (mkNode OR) ((mkTree (mkNode AND) ((mkTree (mkNode C) ()) (mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 8) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 9) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode NOT) ((mkTree (mkNode A) ()))) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 10) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode A) ()) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 11))) (mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 4) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 5) (mkKnob (mkNullVex ((mkTree (mkNode AND) ((mkTree (mkNode A) ()) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 6) (mkKnob (mkNullVex ((mkTree (mkNode AND) ((mkTree (mkNode NOT) ((mkTree (mkNode A) ()))) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 7) (mkTree (mkNode AND) ((mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 12) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 13) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode NOT) ((mkTree (mkNode A) ()))) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 14) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode A) ()) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 15))))) (mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 0) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 1) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode A) ()) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 2) (mkKnob (mkNullVex ((mkTree (mkNode OR) ((mkTree (mkNode NOT) ((mkTree (mkNode A) ()))) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 3) (mkTree (mkNode OR) ((mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 16) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 17) (mkKnob (mkNullVex ((mkTree (mkNode AND) ((mkTree (mkNode NOT) ((mkTree (mkNode A) ()))) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 18) (mkKnob (mkNullVex ((mkTree (mkNode AND) ((mkTree (mkNode A) ()) (mkTree (mkNode B) ()))))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 19))))))
-
-                         (MultiMap.equals $MMap (((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()))) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())))))))
-                True)
-
-;; buildKnobs creates correct number of knobs for single-child PRIORITIZED-OR
+;; 3-arity entry point should canonize/decorate a logical tree and register knobs.
 !(assertEqual (let* (
-    (($updatedTree $MMap) (buildKnobs
-                            (mkTree (mkNode PRIORITIZED-OR)
-                                   (cons (mkTree (mkNode playwin) ()) ()))
-                            () (playwin playblock)))
-    ($mmLength (MultiMap.length $MMap))
+    (($updatedTree $MMap) (buildKnobs (tree1) () (A B)))
+    ($treeChanged (not (== $updatedTree (tree1))))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
 )
-(== $mmLength 5)
+(and $treeChanged $hasKnobs)
 ) True)
 
-;; buildKnobs creates correct number of knobs for game strategies
+;; 4-arity entry point should keep the same logical behavior with explicit disc-probe control.
 !(assertEqual (let* (
-    (($updatedTree $MMap) (buildKnobs (gameTree1) () (playcenter playcorner)))
-    ($mmLength (MultiMap.length $MMap))
+    (($updatedTree $MMap) (buildKnobs (tree1) () (A B) True))
+    ($treeChanged (not (== $updatedTree (tree1))))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
 )
-(== $mmLength 5)
+(and $treeChanged $hasKnobs)
 ) True)
 
-;; buildKnobs modifies tree structure for game strategies
+;; =============================================================================
+;; buildKnobs (5-arity) - action path
+;; =============================================================================
+
+;; Single action in an action sequence exercises the basic action branch.
+(= (simpleActionTree) (mkTree (mkNode and_seq)
+                        (cons (mkTree (mkNode move_forward) ()) ())))
+
+;; 5-arity entry point should dispatch action operators to buildAction.
 !(assertEqual (let* (
-    (($updatedTree $MMap) (buildKnobs
-                            (mkTree (mkNode PRIORITIZED-OR)
-                                   (cons (mkTree (mkNode playwin) ()) ()))
-                            () (playwin playblock)))
-    ($treeChanged (not (== $updatedTree (mkTree (mkNode PRIORITIZED-OR)
-                                               (cons (mkTree (mkNode playwin) ()) ())))))
+    (($updatedTree $MMap) (buildKnobs (simpleActionTree) () () (move_forward turn_left) (A B)))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
 )
-$treeChanged
+$hasKnobs
 ) True)
 
-;; buildKnobs handles nested PRIORITIZED-OR structures
-(= (complexGameTree) (mkTree (mkNode PRIORITIZED-OR)
-                            (cons (mkTree (mkNode playcenter) ())
-                            (cons (mkTree (mkNode PRIORITIZED-OR)
-                                         (cons (mkTree (mkNode playcorner) ())
-                                         (cons (mkTree (mkNode playblock) ()) ())))
-                            ()))))
+;; Conditional action tree checks action_bool_if branch traversal.
+(= (actionIfTree) (mkTree (mkNode action_bool_if)
+                    (cons (mkTree (mkNode ahead_blocked) ())
+                    (cons (mkTree (mkNode move_forward) ())
+                    (cons (mkTree (mkNode turn_left) ()) ())))))
 
-;; buildKnobs creates multiple knobs for nested PRIORITIZED-OR structures
+;; action_bool_if should still create action-selection knobs.
 !(assertEqual (let* (
-    (($updatedTree $MMap) (buildKnobs (complexGameTree) () (playcenter playcorner playblock)))
-    ($mmLength (MultiMap.length $MMap))
-    ($hasCorrectKnobs (>= $mmLength 10)) ;; Expect more than 10 knobs for nested structure (10 per PRIORITIZED-OR)
+    (($updatedTree $MMap) (buildKnobs (actionIfTree) () () (move_forward turn_left) (ahead_blocked A B)))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
 )
-$hasCorrectKnobs
+$hasKnobs
+) True)
+
+;; Degenerate one-action domains should still get simple action knobs.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs (simpleActionTree) () () (move_forward) (ahead_blocked A B)))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
+)
+$hasKnobs
+) True)
+
+;; Custom action/perception symbols model caller-provided discrete domains.
+(= (actions) (grab release walk))
+(= (perceptions) (door-open has-item))
+
+;; Multiple custom leaves verify that non-built-in action symbols are recognized.
+(= (customLeafActionTree) (mkTree (mkNode and_seq)
+                             (cons (mkTree (mkNode grab) ())
+                             (cons (mkTree (mkNode walk) ()) ()))))
+
+;; Mixed custom tree combines plain action leaves with a conditional action.
+(= (myActionTree) (mkTree (mkNode and_seq)
+                     (cons (mkTree (mkNode grab) ())
+                     (cons (mkTree (mkNode walk) ())
+                     (cons (mkTree (mkNode action_bool_if)
+                           (cons (mkTree (mkNode door-open) ())
+                           (cons (mkTree (mkNode release) ())
+                           (cons (mkTree (mkNode grab) ()) ())))) ())))))
+
+;; Multiple custom action leaves should register at least one action knob.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs (customLeafActionTree) () () (actions) (perceptions)))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
+)
+$hasKnobs
+) True)
+
+;; ASK permutations should preserve the original subtree, not only its operator.
+!(assertEqual (let* (
+    (($controlledSubtree $ask) (simpleActionSubtreeKnob (mkTree (mkNode walk) ())))
+    ((mkASK $discKnob $perms) $ask)
+)
+(and (== $controlledSubtree (mkTree (mkNode walk) ()))
+     (== $perms (cons (mkTree (mkNode walk) ()) ())))
+) True)
+
+;; Custom action trees with conditionals should go through the full action path.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs (myActionTree) () () (actions) (perceptions)))
+    ($hasKnobs (> (MultiMap.length $MMap) 0))
+)
+$hasKnobs
 ) True)

--- a/representation/tests/build-knobs-test.metta
+++ b/representation/tests/build-knobs-test.metta
@@ -46,6 +46,63 @@
 ) True)
 
 ;; =============================================================================
+;; buildKnobs - PRIORITIZED-OR strategy path
+;; =============================================================================
+
+;; Simple strategy tree verifies buildKnobs dispatches PRIORITIZED-OR roots.
+(= (gameTree1) (mkTree (mkNode PRIORITIZED-OR)
+                  (cons (mkTree (mkNode playcenter) ())
+                  (cons (mkTree (mkNode playcorner) ()) ()))))
+
+;; Single-child strategy trees should still get strategy knobs.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs
+                            (mkTree (mkNode PRIORITIZED-OR)
+                                   (cons (mkTree (mkNode playwin) ()) ()))
+                            () (playwin playblock)))
+    ($mmLength (MultiMap.length $MMap))
+)
+(== $mmLength 5)
+) True)
+
+;; Multi-child strategy trees should register the expected root knobs.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs (gameTree1) () (playcenter playcorner)))
+    ($mmLength (MultiMap.length $MMap))
+)
+(== $mmLength 5)
+) True)
+
+;; Strategy knob building should modify the original PRIORITIZED-OR tree.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs
+                            (mkTree (mkNode PRIORITIZED-OR)
+                                   (cons (mkTree (mkNode playwin) ()) ()))
+                            () (playwin playblock)))
+    ($treeChanged (not (== $updatedTree (mkTree (mkNode PRIORITIZED-OR)
+                                               (cons (mkTree (mkNode playwin) ()) ())))))
+)
+$treeChanged
+) True)
+
+;; Nested PRIORITIZED-OR trees protect recursive strategy handling.
+(= (complexGameTree) (mkTree (mkNode PRIORITIZED-OR)
+                            (cons (mkTree (mkNode playcenter) ())
+                            (cons (mkTree (mkNode PRIORITIZED-OR)
+                                         (cons (mkTree (mkNode playcorner) ())
+                                         (cons (mkTree (mkNode playblock) ()) ())))
+                            ()))))
+
+;; Nested strategy trees should create knobs for more than the root alone.
+!(assertEqual (let* (
+    (($updatedTree $MMap) (buildKnobs (complexGameTree) () (playcenter playcorner playblock)))
+    ($mmLength (MultiMap.length $MMap))
+    ($hasNestedKnobs (>= $mmLength 10))
+)
+$hasNestedKnobs
+) True)
+
+;; =============================================================================
 ;; buildKnobs (5-arity) - action path
 ;; =============================================================================
 


### PR DESCRIPTION
This PR implements the action-selection knob-building sub-system from C++ MOSES into MeTTa. It enables representation building for action sequences and conditional behaviors, decorates them with Action Subtree Knobs (ASKs).

## Description
1. Domain Modeling & Operator Classification

- Action Classification: Classified structural action operators (such as and_seq, action_bool_if, or_seq, seq_exec, action_while, etc.) and distinguished them from user-defined domain actions.

- Untyped Validation: Introduced helper functions like isDomainAction / isBuiltinAction to treat caller-supplied action lists as the source of truth for primitive actions in MeTTa's untyped environment.

2. Action Subtree Knobs (ASK) Representation (lsk.metta)
Designed and registered two constructors for wrapping action subtrees into discrete knobs:

- Action-Subtree ASK (actionSubtreeKnob): Holds a list of alternate action permutations. Multiplicity is set to $N + 1$ (where index 0 represents the absent choice, and indices 1..N correspond to selected permutations).

- Simple-Action ASK (simpleActionSubtreeKnob): Wraps a single built-in action subtree. Multiplicity is set to $2$ (index 0 is absent, index 1 is present).

3. Stochastic Representation Building (build-action.metta)
Implemented the C++ recursive knob-building algorithm (build_knobs::build_action) with the probability threshold $p = 80:

- Sequences (and_seq):

- Root sequence blocks are decorated with action choice knobs (80% probability).

  - Existing sequence children are mapped recursively: built-in actions are wrapped in simple toggle knobs (20% probability) or sequence wrapper nodes (80% probability).

  - An empty action sequence wrapper is appended at the end of the sequence block with a 20% probability.

- Conditionals (action_bool_if):

  - Traverses the conditional branches while skipping the first child (the perception condition).
  - Recursively processes the action branches, wrapping built-in action branches in sequence nodes.
4. Sampling & Permutations

- Ordered Pair Mapping: Implemented sampleActionPerms and actionPairFromIndex to sample from the ordered action-pair space of size $N \times (N - 1)$ using lazyRandomSelector.

- Conditional Permutations: Paired random perceptions with action choices to produce conditional permutation blocks of the format: (action_bool_if $perception $actA $actB).

5. Candidate Tree Unrolling (appendToASK)
Extended the appendTo dispatcher inside lsk.metta to support unrolling of action selection knobs during candidate scoring:

- Toggle Knobs (Simple-Action): Setting 0 prunes the branch; setting 1 appends the subtree and continues recursive candidate unrolling down the target path.

- Choice Knobs (Action-Subtree): Setting 0 prunes the branch; settings 1..N append the selected permutation and stop recursion at that node.

6. Pre and Post-Processing Passes

- Canonization (actionCanonize): Ensures sequence uniformity by wrapping non-sequential roots under a default and_seq node before knob building.

- Pruning (actionCleanup): Traverses the tree bottom-up (post-order) and removes childless structural operators (and_seq, or_seq, seq_exec), replacing them with null vertices.

7. Entry Point Integration (build-knobs.metta)
Wired the action path into the unified buildKnobs entry point:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## To Follow this
Frame the game strategy evolution as an action selection problem and use action selection operators to evolve a game strategy.

Closes: #465 