### PR TITLE
Ref/Storing Demes inside Atomspace implementaion

### DIFF
--- a/deme/create-deme.metta
+++ b/deme/create-deme.metta
@@ -18,7 +18,7 @@
                   ($reps (createRepresentation $nDeme $exemplar (mkITable $table $labels) $algo $prune-exemplar $enforced-fts  $scorerType))
                   ;; ($_ (println! (done making representations ... $reps)))
             ) 
-            (loopCreateDeme $demeIds $reps ()) ;; FIX: Optimize this using zip implementation in PeTTa. It can be faster.
+            (loopCreateDemeSpace $demeIds $reps ()) ;; FIX: Optimize this using zip implementation in PeTTa. It can be faster.
       ) 
 )
 ;; Game strategy createDeme - creates demes with empty instance sets for game strategies
@@ -38,18 +38,36 @@
       ) 
 )
 
+;; using the mkDeme object
+; (= (loopCreateDeme $demeIds $reps $acc)
+; (if (== $reps ()) 
+;     $acc
+;     (let* (
+;             ($h (car-atom $reps))
+;             ($t (cdr-atom $reps)))
+;          (let* (
+;                  ($demeId (List.head $demeIds)) 
+;                  ($deme (mkDeme $h (mkSInstSet ()) $demeId))
+;                  ($new-acc (union-atom $acc ($deme))))     
+;                (loopCreateDeme (List.tail $demeIds) $t $new-acc)))))
 
-(= (loopCreateDeme $demeIds $reps $acc)
+;;using Deme spaces
+(= (loopCreateDemeSpace $demeIds $reps $acc)
 (if (== $reps ()) 
-    $acc
+    $acc 
     (let* (
             ($h (car-atom $reps))
-            ($t (cdr-atom $reps)))
-         (let* (
-                 ($demeId (List.head $demeIds)) 
-                 ($deme (mkDeme $h (mkSInstSet ()) $demeId))
-                 ($new-acc (union-atom $acc ($deme))))     
-               (loopCreateDeme (List.tail $demeIds) $t $new-acc)))))
+            ($t (cdr-atom $reps))
+            ($demeId (List.head $demeIds)) 
+            ((mkDemeId $id) $demeId)
+            ($demeSpace (py-call (demeSpaceName.demeSpaceName $id)))  
+            ($_ (add-atom $demeSpace $h)) 
+            ($_ (add-atom $demeSpace (mkSInstSet ())))
+            ($_ (add-atom $demeSpace (mkDemeId $id)))
+            ($new-acc (union-atom $acc ($demeSpace)))
+)       
+            (loopCreateDemeSpace (List.tail $demeIds) $t $new-acc))))
+            
 ;; previous version of loopCreateDeme using if-decons-expr-custom
 ;       (if-decons-expr-custom $reps $h $t
 ;             (let* (($demeId (List.head $demeIds)) 

--- a/deme/demeSpaceName.py
+++ b/deme/demeSpaceName.py
@@ -1,0 +1,2 @@
+def demeSpaceName(deme_id):
+    return f"&deme{deme_id}"

--- a/deme/expand-deme.metta
+++ b/deme/expand-deme.metta
@@ -64,7 +64,7 @@
     ;; ($_ (println! "Creating Deme"))
     ($demes (createDeme $nDeme $demeIds $tree $itable $fs-algo $prune-exemplar () $scorerType))
     )
-    (map-atom $demes $deme (expandDemeHelper $deme $truthTableBScore $optimize))
+    (map-atom $demes $deme (expandDemeSpaceHelper $deme $truthTableBScore $optimize))
    ))
 
 ;; Overloaded version for game strategy domain - 8 parameters
@@ -100,6 +100,24 @@
 )
 $optimDeme
 ))
+
+(= (expandDemeSpaceHelper $demeSpace $context $optimize)
+(let*
+(
+   ;  ($lengthOfDscKbMp (Map.length $dscKbMp))
+    ((mkKbMap (mkDscMp $dscKbMp)) (match $demeSpace (mkRep $kbMp $updatedTree) $kbMp))
+    ($lengthOfDscKbMp (Map.length $dscKbMp))
+    ($_ (println! ("length of dscKbMp:" $lengthOfDscKbMp)))
+    ;; ($generatedList (List.generate $lengthOfDscKbMp 0))
+    ($generatedList (createInitialInstance $dscKbMp))
+    ($_ (println! ("generated list:" $generatedList)))
+   ;  ($deme (mkDeme (mkRep (mkKbMap (mkDscKbMp $dscKbMp) (mkDscMp $dscMp)) $updatedTree) $sInstList $demeId))
+    ;; ($_ (println! (Rep: (mkRep (mkKbMap (mkDscKbMp $dscKbMp) (mkDscMp $dscMp)) $updatedTree))))
+    ;; ($_ (println! "Optimizing Deme"))
+    (($inst $optimDeme $state) (optimizeDemes $demeSpace $context (mkInst $generatedList) $optimize))
+)
+$optimDeme
+))
 ;; The main loop 
 ;; Takes 2 termination criterias:
 ;;     - $maxGen : how many times we want the loop to run
@@ -123,8 +141,8 @@ $optimDeme
        ($optimizedDemes (case $context
                         ((($prune-exemplar $fs-algo $truthTableBScore $itable) (trace! "expand  deme returnn" (expandDeme $metaPop $nExpansion $nDeme $prune-exemplar $fs-algo $truthTableBScore $optimize $itable mi)))
                         (($nGames $opponentPolicy $complexityRatio) (trace! "expand deme return" (expandDeme $metaPop $nExpansion $nDeme $nGames $opponentPolicy $complexityRatio $maxScore $optimize))))))
-       (((mkDeme $rep $sInst $demeId)) $optimizedDemes)
-       ($_ (println! (OptimizedDeme: (List.length (second $sInst)))))
+      ;  (((mkDeme $rep $sInst $demeId)) $optimizedDemes)
+      ;  ($_ (println! (OptimizedDeme: $optimizedDemes)))
        ($updatedMetaPop (case $context 
                         ((($prune-exemplar $fs-algo $truthTableBScore $itable) (trace! "Merging Deme" (mergeDemes $optimizedDemes $nEval $maxCandsPerDeme $minPoolSize $complexityTemperature $itable $metaPop $nToKeep $capCoef $genCount)))
                         (($nGames $opponentPolicy $complexityRatio) (trace! "Merging Deme" (mergeDemes $optimizedDemes $nEval $maxCandsPerDeme $minPoolSize $complexityTemperature ($nGames $opponentPolicy) $metaPop $nToKeep $capCoef $genCount))))))

--- a/deme/merge-demes.metta
+++ b/deme/merge-demes.metta
@@ -115,8 +115,8 @@
 ;;   $itable: The input table.
 ;; Return: (List (Exemplar $a)) - List of exemplars with scored trees.
 ; (: demeToTrees (-> Deme (ITable $a) (List (Exemplar $a))))
-(= (demeToTrees (mkDeme $rep (mkSInstSet ()) $demeId) $scoringContext) ())
-(= (demeToTrees (mkDeme $rep (mkSInstSet (cons $si $sil)) $demeId) $scoringContext)
+(= (demeToTrees $rep (mkSInstSet ()) $demeId $scoringContext) ())
+(= (demeToTrees $rep (mkSInstSet (cons $si $sil)) $demeId $scoringContext)
 (let*
     (
         ;; ($_ (println! (===Inside DemeToTrees===)))
@@ -133,7 +133,7 @@
         ($scoredTree (mkExemplar $tree $demeId $cscore $bscore))
         ;; ($_ (println! (Returning...)))
     )
-    (cons $scoredTree (demeToTrees (mkDeme $rep (mkSInstSet $sil) $demeId) $scoringContext))
+    (cons $scoredTree (demeToTrees $rep (mkSInstSet $sil) $demeId $scoringContext))
     )
 )
 ;; Filters a list of Exemplars, keeping only those not already in the metaPop (ordered set).
@@ -243,7 +243,10 @@
             ;; ($_ (println! ("--------------------------------")))
             ;; ($_ (println! (===== MergeDemes Starting =====)))
             (($headDeme $tailDeme) (decons-atom $demes))
-            ((mkDeme $rep $sInstList $demeId) $headDeme)
+            ; ((mkDeme $rep $sInstList $demeId) $headDeme)
+            ($rep (match $headDeme (mkRep $kbmp $tree) (mkRep $kbmp $tree)))
+            ($sInstList (match $headDeme (mkSInstSet $instList) (mkSInstSet $instList)))
+            ($demeId (match $headDeme (mkDemeId $id) (mkDemeId $id)))
             ($sortedSInstList (sortDeme $sInstList)) ;; sorting the instances inside the deme by decreasing order
             ($_ (println! (Demesize: (List.length (second $sortedSInstList)))))
             ;; ($demeExpr (List.listToExpr (second $sortedSInstList)))
@@ -253,7 +256,9 @@
             ($trimmedDeme (trimDownDeme $unqCandidates $minPoolSize $complexityTemperature))  ;; further trims the deme
             ;; ($_ (println! (DemeToTrees Starting...)))
             ($_ (println! (TrimmedDownDeme: (List.length $trimmedDeme))))
-            ($potCandidates (demeToTrees (mkDeme $rep (mkSInstSet $trimmedDeme) $demeId) $scoringContext)) ;;convert instances to trees
+            ($_ (remove-atom $headDeme (mkSInstSet $instList)))
+            ($_ (add-atom $headDeme (mkSInstSet $trimmedDeme)))
+            ($potCandidates (demeToTrees $rep (mkSInstSet $trimmedDeme) $demeId $scoringContext)) ;;convert instances to trees
             ($_ (println! (Before getNewCandidates: (List.length $potCandidates))))
             ;; ($_ (println! (Metapop: $metapop)))
             ;; ($_ (println! ("--")))

--- a/deme/tests/expand-demes-test.metta
+++ b/deme/tests/expand-demes-test.metta
@@ -1,3 +1,4 @@
+!(import! &self ../demeSpaceName.py)
 !(import! &self ../../utilities/general-helpers)
 !(import! &self ../../utilities/list-methods)
 !(import! &self ../../utilities/pair)
@@ -441,3 +442,19 @@
 ;; ;;    )
 ;; ;;    $isValid)
 ;; ;;    True)
+
+;; testcase for the expand demes, using deme spaces
+; !(expandDeme (metaPop2) 0 1 False sim 
+;                     (table1)
+;                     hillClimbing 
+;                     (ttable1)
+;                     mi)
+; !(get-atoms &deme1)
+
+;; testcase for the runMoses, using deme spaces
+; !(runMoses 1 (mkCscore -0.1 2 0.1 0.1 3) 3 (metaPop2) 0 2 (False sim 
+;     (table1) 
+;     (ttable1)) 
+;     hillClimbing 5 2 0 1 
+;     3 0.004 1000)
+    

--- a/moses/neighborhood-sampling.metta
+++ b/moses/neighborhood-sampling.metta
@@ -350,14 +350,16 @@
 ;; Returns:
 ;;   (Deme Number) - Tuple of updated Deme with new scored instances appended and number of new instances added.
 ;; (: sampleNewInstances (-> Number Number Instance Deme Number (Deme Number)))
-(= (sampleNewInstances $totalNeighbors $numNewInstances $centerInst (mkDeme (mkRep (mkKbMap (mkDscMp $disc)) $tree) (mkSInstSet $instList) $demeId) $dist)
+(= (sampleNewInstances $totalNeighbors $numNewInstances $centerInst $demeSpace $dist)
  (let*
   (
     ;; ($_ (println! (DimSize: (Map.length $dkm))))
     ;; ($_ (println! (Inside sampleNewInstances: $totalNeighbors $numNewInstances $centerInst)))
     ;; ($_ (println! (Distance: $dist CenterInst: $centerInst)))
     ;; ($_ (println! ""))
-
+    ((mkKbMap (mkDscMp $disc)) (match $demeSpace (mkRep $kbMp $tree) $kbMp))
+    ; ($_ (println! (Disc: $disc)))
+    ; ($_ (println! (getbyindex: (MultiMap.getByIdx 0 $disc))))
     (($spec $knob) (MultiMap.getByIdx 0 $disc))
     ((mkMultip $m) (getKnobMultip $knob))
     ($kbMp (mkKbMap (mkDscMp $disc)))
@@ -390,26 +392,29 @@
     ;; ($_ (println! (Scored new Instances)))
     ;; ($____ (eval (List.map (|-> ((mkSInst $i)) (printInstance (Pair.first $i))) $scoredNewInstances)))
     ;; ($_ (println! ""))
-
+    ($instList (match $demeSpace (mkSInstSet $list) $list))
+    ; ($_ (println! (instList: $instList)))
     ($updatedInstList (List.concat $instList $scoredNewInstances))
-
+    ; ($_ (println! (updatedInstList: $updatedInstList)))
+    ($_ (remove-atom $demeSpace (mkSInstSet $instList)))
+    ($_ (add-atom $demeSpace (mkSInstSet $updatedInstList)))
     ;; ($_ (println! (UpdatedInst)))
     ;; ($_____ (eval (List.map (|-> ((mkSInst $i)) (printInstance (Pair.first $i))) $updatedInstList)))
-    ;; ($_ (println! ""))
+    ($_ (println! ""))
  )
- ((mkDeme (mkRep $kbMp $tree) (mkSInstSet $updatedInstList) $demeId) $updatedNumNewInstances)))
+ ((mkSInstSet $updatedInstList) $updatedNumNewInstances)))
 ;; similar to the above 'sampleNewInstances' but with slight changes for the feature selection
 ;; Uses the countNeighborhoodFs, sampleFromNeighborhoodFs, initInstScoreFs
 ;; It sets the multiplicy to 2 which is 0 and 1 for the feature selection
 
 ; (: sampleNewInstancesFs (-> Number Number Instance (ITable Bool) (InstanceSet $a) Number ((InstanceSet $a) Number)))
-(= (sampleNewInstancesFs $totalNeighbors $numNewInstances $centerInst $itable (mkSInstSet $instList) $dist)
+(= (sampleNewInstancesFs $totalNeighbors $numNewInstances $centerInst $itable $demeSpace $dist)
  (let*
   (
     ;; ($_ (println! (Inside sampleNewInstancesFs: $totalNeighbors $numNewInstances $centerInst)))
     ;; ($_ (println! (Distance: $dist CenterInst: $centerInst)))
     ;; ($_ (println! ""))
-
+    ($instList (match $demeSpace (mkSInstSet $list) $list))
     ($updatedTotalNeighbors
          (if (> (* 2 $numNewInstances) $totalNeighbors)
              (countNeighborhoodFs $centerInst $dist $numNewInstances)
@@ -423,5 +428,7 @@
                        (generateAllInNeighborhood (mkMultip 2) $centerInst $dist)))
     ($scoredNewInstances (List.map initInstScoreFs $newInstances))
     ($updatedInstList (List.concat $instList $scoredNewInstances))
+    ($_ (remove-atom $demeSpace (mkSInstSet $oldinstList)))
+    ($_ (add-atom $demeSpace (mkSInstSet $updatedInstList)))
  )
  ((mkSInstSet $updatedInstList) $updatedNumNewInstances)))

--- a/moses/tests/demo-problems-benchmark-test.metta
+++ b/moses/tests/demo-problems-benchmark-test.metta
@@ -1,3 +1,4 @@
+!(import! &self ../../deme/demeSpaceName.py)
 !(import! &self ../../utilities/general-helpers)
 !(import! &self ../../utilities/list-methods)
 !(import! &self ../../utilities/pair)
@@ -77,4 +78,7 @@
 ;; When run with nEval of 1000 at this configuration, top result should have a score of 0.
 !(assertEqual (let $result (runDemoProblem 2 10 1 None parity3) (second (index-atom (second $result) 0))) 0)
 ;; TODO: This test case fails because of incorrect creation order when disc probing is enabled. That needs a fix.
-;; !(runDemoProblem 0 10 1 None mux6)
+
+;; tests
+; !(runDemoProblem 2 10 1 None disjunction3)
+; !(runDemoProblem 0 10 1 None mux3)

--- a/optimization/hillclimbing/cross-top-one.metta
+++ b/optimization/hillclimbing/cross-top-one.metta
@@ -12,8 +12,9 @@
 ;;   population and focus on newly generated instances only.
 (= (crossTopOne $deme $nToMake $sampleStart $sampleSize $baseInstance)
             (let* (
-                    ((mkDeme (mkRep (mkKbMap (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId) $deme)
+                    ; ((mkDeme (mkRep (mkKbMap (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId) $deme)
                     ;; ($_ (println! (Inside crossTopOne)))
+                    ($instSet (match $deme (mkSInstSet $instS) $instS))
                     ($nToMakeNew (if (< (- $sampleSize 1) $nToMake) (- $sampleSize 1) $nToMake))
                     ;; ($_ (println! (SampleSize: $sampleSize NToMake: $nToMakeNew SampleStart: $sampleStart totalSize: (List.length $instSet))))
                     (($prevInst $newInst) (List.splitAt $sampleStart $instSet))
@@ -23,7 +24,8 @@
                     ;; ($_ (println! (ListLength: (List.length $list))))
                   )
                   (if (== $list ())
-                      (mkDeme (mkRep (mkKbMap (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId)
+                      ;(mkDeme (mkRep (mkKbMap (mkDscMp $dscMp)) $tree) (mkSInstSet $instSet) $demeId)
+                      (mkSInstSet $instSet)
                       (let*
                         (
                           ((cons $reference $rest) $list)
@@ -37,8 +39,11 @@
                           ;; ($__ (println! (New instances After merging: $newInstances)))
                           ;; ($_ (println! ""))
                           ;; ($_ (println! (PrevInst: $prevInst)))
+                          ($updatedInstSet (mkSInstSet (List.appendList (exprToList $newInstances) $instSet)))
+                          ($_ (remove-atom $deme (mkSInstSet $instList)))
+                          ($_ (add-atom $deme (mkSInstSet $updatedInstSet)))
                         )
-                        (mkDeme (mkRep (mkKbMap (mkDscMp $dscMp)) $tree) (mkSInstSet (List.appendList (exprToList $newInstances) $instSet)) $demeId)))))
+                        $updatedInstSet))))
 
 ;; similar to the above 'crossTopOne' but with slight changes on the comparison function that is passed to the Lost.partialSort to compare the mutualInformation based scores
 ; (: crossTopOneFs (-> (InstanceSet $a) Number Number Number Instance (InstanceSet $a)))

--- a/optimization/hillclimbing/hill-climbing-helpers.metta
+++ b/optimization/hillclimbing/hill-climbing-helpers.metta
@@ -152,6 +152,10 @@
 (= (getDisk (mkDeme (mkRep (mkKbMap $kbMap (mkDscMp $disc)) $tree) $instSet $id)) $disc)
 (= (getDisk (mkDeme (mkRep (mkKbMap (mkDscMp $disc)) $tree) $instSet $id)) $disc)
 
+(= (getDiskfromRep (mkRep (mkKbMap $kbMap (mkDscMp $disc)) $tree)) $disc)
+(= (getDiskfromRep (mkRep (mkKbMap (mkDscMp $disc)) $tree)) $disc)
+
+
 (= (getTTableParams (mkTruthTableBScore $cpxCoeff $size $iTable))
     ($cpxCoeff $size $iTable)
 )
@@ -192,8 +196,13 @@
     (((mkParams applyComplexityBasedScore)
         (let*
           (
-            ($disc (getDisk $POASet))
+            ;;($disc (getDisk $POASet))
+            ($representation (match $POASet (mkRep $kbmp $tree) (mkRep $kbmp $tree)))
+            ;; ($_ (println! (Representation: $representation)))
+            ($disc (getDiskfromRep $representation))
+            ;; ($_ (println! (Disc: $disc)))
             (($cpxCoeff $size $iTable) (getTTableParams $tTableBscorer))
+            ;; ($_ (println! (CpxCoeff: $cpxCoeff Size: $size ITabe: $iTable)))
           )
           (hillClimbing ((min 4 (List.length (second $centerInst))) 400 0) (False False False $centerInst 0 0 (worstCscore) (* -1 (pow-math 10 308)) 0 0 1)
                         $POASet
@@ -250,8 +259,11 @@
         ($_ (println! ""))
         ($_ (println! (Iteration $i running)))
 
-        ($totalNNeighbors ($estimateFunction $d $neighborhood))
-
+        ($totalNNeighbors  ($estimateFunction $d $neighborhood))
+        ($rep (let $return (match $POASet (mkRep $knmp $tree) (mkRep $knmp $tree)) (if (== $return (mkRep () ())) () $return)))
+        ;; ($_ (println! (Representation: $rep)))
+        ($id (let $returnn (match $POASet (mkDemeId $dmid) (mkDemeId $dmid)) (if (== $returnn (mkDemeId ())) () $returnn)))
+        ;; ($_ (println! (DemeId: $id)))
         ;; ($_ (println! (Estimated neighbors: $totalNNeighbors)))
         ;; ($_ (println! ""))
 
@@ -267,14 +279,14 @@
         ($_ (println! ($totalNNeighbors : $nNewNeighbors : $d)))
         ( 
           ; $newPOA
-          ((mkDeme $rep $updatedInstSet $id) $newInstances)
+          ($updatedInstSet $newInstances)
                                                             (case ($xOver $size)
                                                               (
                                                                 ((True ()) (let ($updatedInstSet $newInstances) ($crossoverFunction $currentNInstances $nNewNeighbors $prevStart $prevSize $prevCenter $POASet)
-                                                                              ((mkDeme () $updatedInstSet ()) $newInstances)))
+                                                                              ($updatedInstSet $newInstances)))
                                                                 ((True $notEmpty)  ($crossoverFunction $currentNInstances $nNewNeighbors $prevStart $prevSize $centerInst $POASet))
                                                                 ((False ()) (let ($updatedInstSet $newInstances) ($samplingFunction $totalNNeighbors $nNewNeighbors $centerInst (mkITable $rowOCoeff $neighborhood) $POASet $d)
-                                                                              ((mkDeme () $updatedInstSet ()) $newInstances)))
+                                                                              ($updatedInstSet $newInstances)))
                                                                 ((False $notEmpty)
                                                                         (let $result ($samplingFunction $totalNNeighbors $nNewNeighbors $centerInst $POASet $d)
                                                                         ;; (trace! ("Result: " $result)
@@ -294,7 +306,6 @@
         ;; ($_ (println! ""))
         ;; deconstruct the hyper params for fs function
         (($miConfi $prePenalty $preMinActivation $preMaxActivation $prePositive $scorerType) (if (== () $hyperparamsfs) (() () () () () ()) $hyperparamsfs))
-
         ((mkSInstSet $scoredInstances) (if (or (== $rep ()) (== $id ())) 
                                            ($transformFunction 
                                                                 $updatedInstSet
@@ -308,9 +319,11 @@
                                               ($ComplexityRatio ($transformFunction $updatedInstSet $rep $id ($rowOCoeff $size) $ComplexityRatio))
                                             ))))
 
-        ($updatedDeme (if (or (== $rep ()) (== $id ())) 
-                          (mkSInstSet $scoredInstances) 
-                          (mkDeme $rep (mkSInstSet $scoredInstances) $id)))
+        ; ($updatedDeme (if (or (== $rep ()) (== $id ())) 
+        ;                   (mkSInstSet $scoredInstances) 
+        ;                   (mkDeme $rep (mkSInstSet $scoredInstances) $id)))
+        ($_ (remove-atom $POASet (mkSInstSet $oldinstset)))
+        ($_ (add-atom $POASet (mkSInstSet $scoredInstances)))
         
         ;; ($sExprList (List.listToExpr $scoredInstances))
         ;; ($amr (map-atom $sExprList $inst (let (mkSInst $x) $inst (println! (Inst: (List.listToExpr (second (Pair.first $x))) Tree: (preOrder (getCandidate $rep $id (Pair.first $x))) Score: (getPenScore (Pair.second $x)))))))
@@ -341,12 +354,12 @@
                               (if (and (== $totalNNeighbors 1) (== $nextDistance 1))
                                   (hillClimbing ($maxDist $minXoverNeighbors $bestPossibleScore)
                                                 ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $prevStart $prevSize $nextBestSscore $nextBestScore (+ $currentNInstances $newInstances) $nextDistance (+ 1 $i)) ;; Updated state
-                                                $updatedDeme
+                                                $POASet
                                                 ($neighborhood $rowOCoeff $size $iTable)
                                                 $nextCenterInst
                                                 $hyperparamsfs
                                                 $estimateFunction $crossoverFunction $samplingFunction $transformFunction)
-                                  ($nextCenterInst $updatedDeme ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $currentNInstances $newInstances $nextBestSscore $nextBestScore (+ $currentNInstances $newInstances) $nextDistance $i))))
+                                  ($nextCenterInst $POASet ((and $xOver (not $hasImproved)) $lastChance $hasImproved $centerInst $currentNInstances $newInstances $nextBestSscore $nextBestScore (+ $currentNInstances $newInstances) $nextDistance $i))))
         
         ($scoreToCompareBelow (if (or (== $rep ()) (== $id ())) $newBestSscore (getPenScore $newBestSscore)))
         ;; ($_ (println! (Found newBestSscore After (+ 1 $i) iteration is: $newBestSscore $scoreToCompareBelow)))

--- a/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
+++ b/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
@@ -1,3 +1,4 @@
+!(import! &self ../../../deme/demeSpaceName.py)
 !(import! &self ../../../utilities/general-helpers)
 !(import! &self ../../../utilities/list-methods)
 !(import! &self ../../../utilities/nodeId)
@@ -231,3 +232,14 @@
 ;;
 ;; !(assertEqual (hillClimbing (strategyDeme) (mkCscore 3.0 5 1.43 0.0 3) (mkInst (cons 1 (cons 1 ()))) (mkParams applyStrategyBasedScore (3 3.5))
 ;; ) ((mkInst (1 1)) (mkDeme (mkRep (mkKbMap (mkDscKbMp (((mkNodeId (1)) 0) ((mkNodeId (2)) 1))) (mkDscMp (((mkDiscSpec 2) (mkSSK (mkDiscKnob (mkKnob (mkNodeId (1))) (mkMultip 2) (mkDiscSpec 1) (mkDiscSpec 1) ()))) ((mkDiscSpec 2) (mkSSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 2) (mkDiscSpec 1) (mkDiscSpec 1) ())))))) (mkTree (mkNode PRIORITIZED-OR) ((mkTree (mkNode playwin) ()) (mkTree (mkNode playblock) ())))) (mkSInstSet ((mkSInst (mkPair (mkInst (0 1)) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))) (mkSInst (mkPair (mkInst (1 1)) (mkCscore -3.0 2 0.5714285714285714 0.0 -3.571428571428571))) (mkSInst (mkPair (mkInst (0 1)) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))) (mkSInst (mkPair (mkInst (1 0)) (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856))))) (mkDemeId "1")) (true false false (mkInst (1 1)) 3 1 (mkCscore -3.0 1 0.2857142857142857 0.0 -3.2857142857142856) -3.2857142857142856 4 2 3)))
+
+;; hillclimbing test for the deme spaces version
+
+; !(add-atom &demeSpace (mkRep (mkKbMap (mkDscMp (((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) )) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())))))) (mkTree (mkNode AND) ( (mkKnob (mkNullVex ((mkTree (mkNode A) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 0) (mkKnob (mkNullVex ((mkTree (mkNode B) ()))) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 1)))))
+
+; !(add-atom &demeSpace (mkSInstSet ()))
+; !(add-atom &demeSpace (mkDemeId "1"))
+
+; !(hillClimbing &demeSpace (table1) (mkInst (cons 0 (cons 2 ()))))
+
+; !(get-atoms &demeSpace)


### PR DESCRIPTION
Refactors deme storage from the mkDeme object to MeTTa atomspaces, one per deme. Each deme's representation, instance set, and ID are now stored as separate atoms in a dedicated space instead of bundled into a single mkDeme tuple.
Changes:
- CreateDeme creates a new-space per deme and stores Representation, Instance set, and Deme id as separate atoms.
- HillClimbing optimization, Deme expansion, crossover,  New Instances sampling, and Merging Demes now read/write the deme space via space operations instead of passing mkDeme values by return.

## Motivation and Context
Using the mkDeme object forces every function in the deme pipeline to destructure and rebuild the  tuple even when only the instance set changes. Storing each deme in its own space decouples the fields and sets up future parallel deme processing since each deme's state is isolated.

## How Has This Been Tested?
It has been tested  inside a petta environment and testcases have been added. More over, the changes have been tested using the demo problems found in the codebase. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
