### PR TITLE
action reduction foundation — vocabulary, helpers, properties, and result-based truncation

### DIFF
--- a/reduct/action-reduct/action-helpers.metta
+++ b/reduct/action-reduct/action-helpers.metta
@@ -1,0 +1,235 @@
+;; ---------------------------------------------------------------------------
+;; Action Reduction Helpers
+;; ---------------------------------------------------------------------------
+
+;; These helpers support the action-reduction rules by answering two kinds of
+;; questions:
+;;   1. static action-result questions, using the tribool values True, False,
+;;      and Unknown;
+;;   2. tuple-shaping questions, such as flattening associative sequence nodes
+;;      or pruning sequence constants while preserving child order.
+;;
+;; `alwaysSucceeds` is defined in action-vocab.metta. It marks primitive actions
+;; whose success is known independent of runtime world state.
+
+;; ---------------------------------------------------------------------------
+;; getActionResult: evaluates the static success status of an action expression.
+;; The result is a tribool: True, False, or Unknown. 
+;; Important cases:
+;; - action_not inverts only known results; Unknown remains Unknown.
+;; - and_seq/or_seq delegate to sequence-specific folds below.
+;; - exec_seq is statically successful because it does not depend on child
+;;   success values in the action-reduction model.
+;; - action_action_if can only reduce statically when the condition's action
+;;   result is known; otherwise either branch may be taken at runtime.
+;; ---------------------------------------------------------------------------
+
+(= (getActionResult $expr)
+   (if (== (get-metatype $expr) Expression)
+       (if (== $expr ())
+           Unknown
+           (let ($op $args) (decons $expr)
+             (case $op
+               ((action_not
+                 (let* (($child (car-atom $args))
+                        ($r (getActionResult $child)))
+                   (if (== $r True)
+                       False
+                       (if (== $r False) True Unknown))))
+                (and_seq (getActionResultAnd $args))
+                (or_seq  (getActionResultOr $args))
+                (exec_seq True)
+                (action_while False)
+                (action_action_if
+                 (let* (($cond (car-atom $args))
+                        ($br1 (car-atom (cdr-atom $args)))
+                        ($br2 (car-atom (cdr-atom (cdr-atom $args))))
+                        ($cRes (getActionResult $cond)))
+                   (if (== $cRes True)
+                        (getActionResult $br1)
+                        (if (== $cRes False) (getActionResult $br2) Unknown))))
+                ($else Unknown)))))
+       (case $expr
+         ((action_success True)
+           (action_failure False)
+           ($else (if (alwaysSucceeds $expr) True Unknown))))))
+
+;; getActionResultAnd: and_seq succeeds only when every child is statically
+;; True; the first False or Unknown is enough to determine the static result.
+(= (getActionResultAnd ()) True)
+(= (getActionResultAnd $args)
+   (let* ((($h $t) (decons $args))
+          ($r (getActionResult $h)))
+     (if (== $r True)
+         (getActionResultAnd $t)
+         $r)))
+
+;; getActionResultOr: or_seq succeeds at the first statically True child.
+;; If every child is False, the whole sequence is False. If no child is True
+;; but at least one child is Unknown, the sequence remains Unknown.
+(= (getActionResultOr $args) (getActionResultOrHelper $args False))
+
+;; `$exists_indeterminate` records whether an earlier child was Unknown while
+;; scanning for a True child. That lets the base case distinguish "all False"
+;; from "no True, but at least one Unknown".
+(= (getActionResultOrHelper () $exists_indeterminate)
+   (if $exists_indeterminate Unknown False))
+(= (getActionResultOrHelper $args $exists_indeterminate)
+   (let* ((($h $t) (decons $args))
+          ($r (getActionResult $h)))
+     (if (== $r True)
+         True
+         (getActionResultOrHelper $t (or $exists_indeterminate (== $r Unknown))))))
+
+;; ---------------------------------------------------------------------------
+;; List/Tuple Simplification Helpers
+;; ---------------------------------------------------------------------------
+
+;; flattenAssoc: flattens nested occurrences of the associative operator $op.
+;; For example, `(and_seq A (and_seq B C) D)` becomes `(A B C D)` at the
+;; argument-list level; the caller reattaches the operator. This mirrors the C++
+;; `level` rule, which splices children of the same associative parent into the
+;; current sibling list.
+;;
+;; The helper recurses into matching child operators before concatenating so
+;; deeper nests are flattened in one pass: f(a, f(b, f(c, d))) -> (a b c d).
+;; Non-expression children, empty expressions, and expressions with a different
+;; operator are preserved exactly in their original position.
+(= (flattenAssoc $op $args)
+   (if (== $args ())
+       ()
+       (let* ((($h $t) (decons $args))
+              ($flatTail (flattenAssoc $op $t)))
+         (if (and (== (get-metatype $h) Expression) (!= $h ()))
+             (let ($childOp $childArgs) (decons $h)
+               (if (== $childOp $op)
+                   (concatTuple (flattenAssoc $op $childArgs) $flatTail)
+                   (cons-atom $h $flatTail)))
+             (cons-atom $h $flatTail)))))
+
+;; pruneAndSeqArgs: simplify and_seq argument lists.
+;; - `action_success` is the identity element for and_seq, so it is dropped.
+;; - The first `action_failure` determines the whole and_seq result, so all
+;;   later siblings are unreachable and the list is truncated there.
+;; - Unknown/domain-dependent actions are kept in order.
+(= (pruneAndSeqArgs $args)
+   (if (== $args ())
+       ()
+       (let ($h $t) (decons $args)
+         (if (== $h action_failure)
+             (cons-atom action_failure ())
+             (if (== $h action_success)
+                 (pruneAndSeqArgs $t)
+                 (cons-atom $h (pruneAndSeqArgs $t)))))))
+
+;; pruneOrSeqArgs: simplify or_seq argument lists.
+;; - `action_failure` is the identity element for or_seq, so it is dropped.
+;; - The first `action_success` determines the whole or_seq result, so all later
+;;   siblings are unreachable and the list is truncated there.
+;; - Unknown/domain-dependent actions are kept in order.
+(= (pruneOrSeqArgs $args)
+   (if (== $args ())
+       ()
+       (let ($h $t) (decons-atom $args)
+         (if (== $h action_success)
+             (cons-atom action_success ())
+             (if (== $h action_failure)
+                 (pruneOrSeqArgs $t)
+                 (cons-atom $h (pruneOrSeqArgs $t)))))))
+
+;; pruneExecSeqArgs: simplify exec_seq argument lists.
+;; exec_seq runs actions for their effects and does not branch on action result,
+;; so both action_success and action_failure are no-op constants here. Other
+;; actions are preserved in their original order.
+(= (pruneExecSeqArgs $args)
+   (if (== $args ())
+       ()
+       (let ($h $t) (decons-atom $args)
+         (if (or (== $h action_success) (== $h action_failure))
+             (pruneExecSeqArgs $t)
+             (cons-atom $h (pruneExecSeqArgs $t))))))
+
+;; truncateAtAlwaysFails: keep arguments up to and including the first child
+;; whose static action result is False. This is useful for reductions where
+;; later siblings cannot affect the result once a guaranteed failure appears.
+(= (truncateAtAlwaysFails $args)
+   (if (== $args ())
+       ()
+       (let* ((($h $t) (decons-atom $args))
+              ($r (getActionResult $h)))
+         (if (== $r False)
+             (cons-atom $h ())
+             (cons-atom $h (truncateAtAlwaysFails $t))))))
+
+;; truncateAtAlwaysSucceeds: keep arguments up to and including the first child
+;; whose static action result is True. This is the dual of
+;; truncateAtAlwaysFails and supports or_seq-style early-exit reductions.
+(= (truncateAtAlwaysSucceeds $args)
+   (if (== $args ())
+       ()
+       (let* ((($h $t) (decons-atom $args))
+              ($r (getActionResult $h)))
+         (if (== $r True)
+             (cons-atom $h ())
+             (cons-atom $h (truncateAtAlwaysSucceeds $t))))))
+
+;; ---------------------------------------------------------------------------
+;; smallestDivisor: returns the smallest divisor greater than 1.
+;; Prime numbers return themselves. The modular-argument reducer uses this for
+;; simple factor-style normalization of numeric action parameters.
+;; ---------------------------------------------------------------------------
+(= (smallestDivisor $n) (smallestDivisorFrom $n 2))
+
+;; Trial division from `$d` upward.
+(= (smallestDivisorFrom $n $d)
+   (if (>= $d $n)
+       $n
+       (if (== (% $n $d) 0)
+           $d
+           (smallestDivisorFrom $n (+ $d 1)))))
+
+;; ---------------------------------------------------------------------------
+;; substituteCondInitInstant: replaces occurrences of `$cond` with `$sub` only
+;; where the condition is evaluated at the initial instant of an action program.
+;;
+;; The traversal is deliberately selective:
+;; - sequence nodes (`and_seq`, `or_seq`, `exec_seq`) substitute only in the
+;;   first child because that child is the only part known to run initially;
+;; - action_bool_if substitutes through the condition and both branches because
+;;   it is a boolean expression constructor;
+;; - action_action_if substitutes only in its action condition, leaving action
+;;   branches unchanged because they occur after the condition has executed.
+;; ---------------------------------------------------------------------------
+
+(= (substituteSeqInit $expr $op $args $cond $sub)
+   (if (== $args ())
+       $expr
+       (let* ((($h $t) (decons $args))
+              ($newH (substituteCondInitInstant $h $cond $sub)))
+         (cons-atom $op (cons-atom $newH $t)))))
+
+(= (substituteCondInitInstant $expr $cond $sub)
+   (if (== $expr $cond)
+       $sub
+       (if (and (== (get-metatype $expr) Expression) (!= $expr ()))
+           (let ($op $args) (decons $expr)
+             (case $op
+                ((and_seq (substituteSeqInit $expr and_seq $args $cond $sub))
+                 (or_seq (substituteSeqInit $expr or_seq $args $cond $sub))
+                 (exec_seq (substituteSeqInit $expr exec_seq $args $cond $sub))
+                 (action_bool_if
+                  (let* (($c (car-atom $args))
+                         ($b1 (car-atom (cdr-atom $args)))
+                         ($b2 (car-atom (cdr-atom (cdr-atom $args)))))
+                    (action_bool_if (substituteCondInitInstant $c $cond $sub)
+                                    (substituteCondInitInstant $b1 $cond $sub)
+                                    (substituteCondInitInstant $b2 $cond $sub))))
+                 (action_action_if
+                  (let* (($c (car-atom $args))
+                         ($b1 (car-atom (cdr-atom $args)))
+                         ($b2 (car-atom (cdr-atom (cdr-atom $args)))))
+                    (action_action_if (substituteCondInitInstant $c $cond $sub)
+                                      $b1
+                                      $b2)))
+                 ($else $expr))))
+            $expr)))

--- a/reduct/action-reduct/action-properties.metta
+++ b/reduct/action-reduct/action-properties.metta
@@ -1,0 +1,70 @@
+;; ---------------------------------------------------------------------------
+;; Domain property declarations and default fallbacks
+;; ---------------------------------------------------------------------------
+
+;; Note: The default ant-problem actions lack idempotent, additive, zero-neutral,
+;; or modular properties. Dummy actions (dummy_*) are mapped here specifically
+;; to serve as mock elements for unit-testing these properties' reduction rules.
+
+;; The core action reduction rules (like reduceIdempotent, reduceAdditive, and
+;; reduceModularArgument) are written to be domain-independent. They form a
+;; general action reduction engine. By defining the interface hooks here in
+;; action-properties.metta, we separate the generic reduction engine from the
+;; specific vocabulary. Later, if one wants to use this engine for a different
+;; problem, e.g., a robotic arm domain with a rotate(angle) action or a
+;; grid-world turtle domain with a step_forward(distance) action, one can
+;; easily add those properties here without modifying any code inside the
+;; core reduction rules.
+
+;; Checks if an action is idempotent. Real-world example: actions like
+;; "stop" or "grab_food" (repeating them consecutively has no extra effect).
+(= (isIdempotent $action)
+   (== $action dummy_idempotent_action))
+
+;; Checks if an action is reversible. Ant problem example: "turn_left"
+;; and "turn_right" are opposite actions that undo each other.
+(= (isReversible $action)
+   (is-member $action (turn_left turn_right)))
+
+;; Returns the reversing action. Ant problem example: the reversal of
+;; "turn_left" is "turn_right", and vice-versa.
+(= (getReversal $action)
+   (case $action
+     ((turn_left turn_right)
+      (turn_right turn_left)
+      ($else $action))))
+
+;; Checks if sequential actions can sum their argument. Real-world example:
+;; two sequential moves "step(1)" and "step(2)" can sum to "step(3)".
+(= (isAdditive $action $index)
+   (is-member ($action $index)
+              ((dummy_additive_action 0))))
+
+;; Checks if an argument of 0 makes the action a no-op. Real-world
+;; example: "step(0)" immediately succeeds without moving the agent.
+(= (isZeroNeutral $action $index)
+   (is-member ($action $index)
+              ((dummy_zero_neutral_action 0))))
+
+;; Checks if an argument is periodic/modular. Real-world example:
+;; rotation angles that wrap around every 360 degrees or 2pi radians.
+(= (isModulo $action $index)
+   (is-member ($action $index)
+              ((dummy_modular_action 0)
+               (dummy_modular_action 1))))
+
+;; Returns the lower bound of a periodic argument (e.g. -3.14 for radians
+;; or -180 for degrees).
+(= (moduloMin $action $index)
+   (case ($action $index)
+     (((dummy_modular_action 0) -3.14)
+      ((dummy_modular_action 1) -30)
+      ($else 0))))
+
+;; Returns the upper bound of a periodic argument (e.g. 3.14 for radians
+;; or 180 for degrees).
+(= (moduloMax $action $index)
+   (case ($action $index)
+     (((dummy_modular_action 0) 3.14)
+      ((dummy_modular_action 1) 30)
+      ($else 0))))

--- a/reduct/action-reduct/action-vocab.metta
+++ b/reduct/action-reduct/action-vocab.metta
@@ -1,0 +1,40 @@
+;; ---------------------------------------------------------------------------
+;; Action Operator Vocabulary and Constants
+;; ---------------------------------------------------------------------------
+
+;; Constants
+;; action_success - Terminal successful action
+;; action_failure - Terminal failed action
+
+;; Operators:
+;; and_seq         - Sequential execution: execute all, stop/fail at first failure
+;; or_seq          - Sequential execution: execute until first success
+;; exec_seq        - Sequential execution: execute all, ignore results
+;; action_not      - Negation of action result
+;; action_bool_if  - Conditional branch with boolean condition
+;; bool_action_if  - Conditional branch (boolean output) with action condition
+;; contin_action_if - Conditional branch (continuous output) with action condition
+;; action_action_if - Conditional branch (action output) with action condition
+;; action_while    - Loop while action succeeds
+;; bool_while      - Loop while boolean condition is true
+
+;; ---------------------------------------------------------------------------
+;; Domain Environment Actions property facts
+;; ---------------------------------------------------------------------------
+
+;; alwaysSucceeds: static action_result oracle used by reducers.
+;;
+;; This must be conservative for the generic MeTTa port. The C++ ant vocabulary
+;; marks move_forward/turn_left/turn_right as always_succeeds because the
+;; example-ant world permits those actions and reports action_success for them.
+;; In other domains, especially pet-brain grid worlds with blocked movement,
+;; move_forward/step_forward may fail or be impossible. Keep such movement
+;; actions Unknown unless a domain-specific vocabulary imports stronger facts.
+
+(= (alwaysSucceeds $action)
+   (is-member $action (turn_left turn_right)))
+
+;; referenceAntAlwaysSucceeds records the original C++ ant-vocabulary facts for
+;; reference/parity fixtures. Generic reducers intentionally do not call it.
+(= (referenceAntAlwaysSucceeds $action)
+   (is-member $action (move_forward turn_left turn_right)))

--- a/reduct/action-reduct/reduce-seq-result.metta
+++ b/reduct/action-reduct/reduce-seq-result.metta
@@ -1,0 +1,23 @@
+;; ---------------------------------------------------------------------------
+;; Result-based truncation for sequential logical operators
+;; ---------------------------------------------------------------------------
+
+;; Truncate and_seq after first element that always fails
+(= (reduceSeqAndAlwaysFails $expr)
+   (if (and (== (get-metatype $expr) Expression) (!= $expr ()))
+       (let ($op $args) (decons $expr)
+         (if (== $op and_seq)
+             (let $truncated (truncateAtAlwaysFails $args)
+               (cons-atom and_seq $truncated))
+             $expr))
+       $expr))
+
+;; Truncate or_seq after first element that always succeeds
+(= (reduceSeqOrAlwaysSucceeds $expr)
+   (if (and (== (get-metatype $expr) Expression) (!= $expr ()))
+       (let ($op $args) (decons $expr)
+         (if (== $op or_seq)
+             (let $truncated (truncateAtAlwaysSucceeds $args)
+               (cons-atom or_seq $truncated))
+             $expr))
+       $expr))

--- a/reduct/action-reduct/tests/action-helpers-test.metta
+++ b/reduct/action-reduct/tests/action-helpers-test.metta
@@ -1,0 +1,130 @@
+!(import! &self ../../../utilities/general-helpers)
+!(import! &self ../action-vocab)
+!(import! &self ../action-helpers)
+
+;; ============================================================================
+;; getActionResult tribool oracle
+;; ============================================================================
+
+;; Terminal constants
+!(assertEqual (getActionResult action_success) True)
+!(assertEqual (getActionResult action_failure) False)
+
+;; exec_seq always succeeds statically
+!(assertEqual (getActionResult (exec_seq)) True)
+
+;; Primitive action dispatch via alwaysSucceeds
+!(assertEqual (getActionResult move_forward) Unknown)
+!(assertEqual (getActionResult step_forward) Unknown)
+!(assertEqual (getActionResult turn_left) True)
+
+;; action_while always fails statically
+!(assertEqual (getActionResult (action_while action_success)) False)
+
+;; action_not inverts known results, passes through Unknown
+!(assertEqual (getActionResult (action_not action_success)) False)
+!(assertEqual (getActionResult (action_not action_failure)) True)
+!(assertEqual (getActionResult (action_not move_forward)) Unknown)
+
+;; and_seq: needs all children statically True
+!(assertEqual (getActionResult (and_seq action_success move_forward)) Unknown)
+!(assertEqual (getActionResult (and_seq action_success action_failure)) False)
+
+;; or_seq: succeeds at first statically True child
+!(assertEqual (getActionResult (or_seq action_failure action_success)) True)
+!(assertEqual (getActionResult (or_seq action_failure move_forward)) Unknown)
+!(assertEqual (getActionResult (or_seq action_failure action_failure)) False)
+
+;; Other operators: not statically reduced → Unknown
+!(assertEqual (getActionResult (bool_while (near stick tree) step_forward)) Unknown)
+!(assertEqual (getActionResult (bool_action_if move_forward A B)) Unknown)
+!(assertEqual (getActionResult (contin_action_if move_forward A B)) Unknown)
+!(assertEqual (getActionResult (and_seq (goto_obj stick))) Unknown)
+!(assertEqual (getActionResult (action_action_if (goto_obj stick) step_forward turn_left)) Unknown)
+!(assertEqual (getActionResult (or_seq (goto_obj stick) step_forward)) Unknown)
+
+;; ============================================================================
+;; flattenAssoc: flatten nested associative operators at the argument-list level
+;; ============================================================================
+!(assertEqual (flattenAssoc and_seq (A (and_seq B C) D)) (A B C D))
+!(assertEqual (flattenAssoc or_seq (A (or_seq B C) D)) (A B C D))
+!(assertEqual (flattenAssoc exec_seq (A (exec_seq B C) D)) (A B C D))
+!(assertEqual (flattenAssoc and_seq (A (and_seq B (and_seq C D)))) (A B C D))
+
+;; ============================================================================
+;; pruneAndSeqArgs: remove action_success, truncate at action_failure
+;; ============================================================================
+!(assertEqual (pruneAndSeqArgs ()) ())
+!(assertEqual (pruneAndSeqArgs (action_success)) ())
+!(assertEqual (pruneAndSeqArgs (action_failure)) (action_failure))
+!(assertEqual (pruneAndSeqArgs (action_success A action_failure B)) (A action_failure))
+!(assertEqual (pruneAndSeqArgs (A action_success B)) (A B))
+
+;; ============================================================================
+;; pruneOrSeqArgs: remove action_failure, truncate at action_success
+;; ============================================================================
+!(assertEqual (pruneOrSeqArgs ()) ())
+!(assertEqual (pruneOrSeqArgs (action_failure)) ())
+!(assertEqual (pruneOrSeqArgs (action_success)) (action_success))
+!(assertEqual (pruneOrSeqArgs (action_failure A action_success B)) (A action_success))
+!(assertEqual (pruneOrSeqArgs (A action_failure B)) (A B))
+
+;; ============================================================================
+;; pruneExecSeqArgs: remove both action_success and action_failure
+;; ============================================================================
+!(assertEqual (pruneExecSeqArgs ()) ())
+!(assertEqual (pruneExecSeqArgs (action_success)) ())
+!(assertEqual (pruneExecSeqArgs (action_failure)) ())
+!(assertEqual (pruneExecSeqArgs (action_success A action_failure B)) (A B))
+!(assertEqual (pruneExecSeqArgs (A action_success B action_failure C)) (A B C))
+
+;; ============================================================================
+;; truncateAtAlwaysFails: keep args up to and including first statically False
+;; ============================================================================
+!(assertEqual (truncateAtAlwaysFails ()) ())
+!(assertEqual (truncateAtAlwaysFails (turn_left move_forward action_failure B)) (turn_left move_forward action_failure))
+
+;; ============================================================================
+;; truncateAtAlwaysSucceeds: keep args up to and including first statically True
+;; ============================================================================
+!(assertEqual (truncateAtAlwaysSucceeds ()) ())
+!(assertEqual (truncateAtAlwaysSucceeds (move_forward turn_left B)) (move_forward turn_left))
+!(assertEqual (truncateAtAlwaysSucceeds (action_failure action_failure turn_left B)) (action_failure action_failure turn_left))
+
+;; ============================================================================
+;; smallestDivisor: smallest divisor > 1 (primes return themselves)
+;; ============================================================================
+!(assertEqual (smallestDivisor 2) 2)
+!(assertEqual (smallestDivisor 3) 3)
+!(assertEqual (smallestDivisor 4) 2)
+!(assertEqual (smallestDivisor 9) 3)
+!(assertEqual (smallestDivisor 15) 3)
+!(assertEqual (smallestDivisor 17) 17)
+
+;; ============================================================================
+;; substituteCondInitInstant: condition substitution limited to initial instant
+;; ============================================================================
+
+;; Direct match
+!(assertEqual (substituteCondInitInstant X X Y) Y)
+;; Non-match passthrough
+!(assertEqual (substituteCondInitInstant X Y Z) X)
+
+;; and_seq: substitute only in first child
+!(assertEqual (substituteCondInitInstant (and_seq X A) X Y) (and_seq Y A))
+!(assertEqual (substituteCondInitInstant (and_seq A X) X Y) (and_seq A X))
+
+;; or_seq: substitute only in first child
+!(assertEqual (substituteCondInitInstant (or_seq X A) X Y) (or_seq Y A))
+
+;; exec_seq: substitute only in first child
+!(assertEqual (substituteCondInitInstant (exec_seq X A) X Y) (exec_seq Y A))
+
+;; action_bool_if: substitute in condition and both branches
+!(assertEqual (substituteCondInitInstant (action_bool_if X A B) X Y) (action_bool_if Y A B))
+
+;; action_action_if: substitute in condition only, NOT in branches
+!(assertEqual (substituteCondInitInstant (action_action_if X X X) X Y) (action_action_if Y X X))
+
+;; Verify the difference between action_bool_if and action_action_if branch handling
+!(assertEqual (substituteCondInitInstant (action_bool_if X X X) X Y) (action_bool_if Y Y Y))

--- a/reduct/action-reduct/tests/action-properties-test.metta
+++ b/reduct/action-reduct/tests/action-properties-test.metta
@@ -1,0 +1,49 @@
+!(import! &self ../../../utilities/general-helpers)
+!(import! &self ../action-properties)
+
+;; ============================================================================
+;; isIdempotent: only dummy_idempotent_action is idempotent by default
+;; ============================================================================
+!(assertEqual (isIdempotent dummy_idempotent_action) True)
+!(assertEqual (isIdempotent move_forward) False)
+!(assertEqual (isIdempotent turn_left) False)
+
+;; ============================================================================
+;; isReversible / getReversal: turn_left and turn_right are a reversible pair
+;; ============================================================================
+!(assertEqual (isReversible turn_left) True)
+!(assertEqual (isReversible turn_right) True)
+!(assertEqual (isReversible move_forward) False)
+
+!(assertEqual (getReversal turn_left) turn_right)
+!(assertEqual (getReversal turn_right) turn_left)
+!(assertEqual (getReversal move_forward) move_forward)
+
+;; ============================================================================
+;; isAdditive: only dummy_additive_action at index 0 is additive
+;; ============================================================================
+!(assertEqual (isAdditive dummy_additive_action 0) True)
+!(assertEqual (isAdditive dummy_additive_action 1) False)
+!(assertEqual (isAdditive move_forward 0) False)
+
+;; ============================================================================
+;; isZeroNeutral: only dummy_zero_neutral_action at index 0
+;; ============================================================================
+!(assertEqual (isZeroNeutral dummy_zero_neutral_action 0) True)
+!(assertEqual (isZeroNeutral dummy_zero_neutral_action 1) False)
+!(assertEqual (isZeroNeutral move_forward 0) False)
+
+;; ============================================================================
+;; isModulo / moduloMin / moduloMax: only dummy_modular_action at indices 0, 1
+;; ============================================================================
+!(assertEqual (isModulo dummy_modular_action 0) True)
+!(assertEqual (isModulo dummy_modular_action 1) True)
+!(assertEqual (isModulo dummy_modular_action 2) False)
+!(assertEqual (isModulo move_forward 0) False)
+
+!(assertEqual (isApproxEq (moduloMin dummy_modular_action 0) -3.14) True)
+!(assertEqual (isApproxEq (moduloMax dummy_modular_action 0) 3.14) True)
+!(assertEqual (isApproxEq (moduloMin dummy_modular_action 1) -30) True)
+!(assertEqual (isApproxEq (moduloMax dummy_modular_action 1) 30) True)
+!(assertEqual (moduloMin move_forward 0) 0)
+!(assertEqual (moduloMax move_forward 0) 0)

--- a/reduct/action-reduct/tests/action-vocab-test.metta
+++ b/reduct/action-reduct/tests/action-vocab-test.metta
@@ -1,0 +1,18 @@
+!(import! &self ../../../utilities/general-helpers)
+!(import! &self ../action-vocab)
+
+;; alwaysSucceeds oracle — conservative defaults (no domain-specific overrides)
+!(assertEqual (alwaysSucceeds turn_left) True)
+!(assertEqual (alwaysSucceeds turn_right) True)
+!(assertEqual (alwaysSucceeds move_forward) False)
+!(assertEqual (alwaysSucceeds step_forward) False)
+!(assertEqual (alwaysSucceeds action_success) False)
+!(assertEqual (alwaysSucceeds action_failure) False)
+!(assertEqual (alwaysSucceeds (goto_obj stick)) False)
+
+;; referenceAntAlwaysSucceeds — C++ ant-domain parity for regression checks
+!(assertEqual (referenceAntAlwaysSucceeds move_forward) True)
+!(assertEqual (referenceAntAlwaysSucceeds turn_left) True)
+!(assertEqual (referenceAntAlwaysSucceeds turn_right) True)
+!(assertEqual (referenceAntAlwaysSucceeds step_forward) False)
+!(assertEqual (referenceAntAlwaysSucceeds action_success) False)

--- a/reduct/action-reduct/tests/reduce-seq-result-test.metta
+++ b/reduct/action-reduct/tests/reduce-seq-result-test.metta
@@ -1,0 +1,52 @@
+!(import! &self ../../../utilities/general-helpers)
+!(import! &self ../action-vocab)
+!(import! &self ../action-helpers)
+!(import! &self ../reduce-seq-result)
+
+;; ============================================================================
+;; reduceSeqAndAlwaysFails: truncate and_seq after first statically-False child
+;; ============================================================================
+
+;; Existing test: no statically-False child → no truncation
+!(assertEqual
+  (reduceSeqAndAlwaysFails (and_seq A move_forward action_failure B))
+  (and_seq A move_forward action_failure))
+
+;; Non-and_seq operator → passthrough unchanged
+!(assertEqual
+  (reduceSeqAndAlwaysFails (exec_seq A action_failure B))
+  (exec_seq A action_failure B))
+
+;; Empty and_seq → passthrough
+!(assertEqual
+  (reduceSeqAndAlwaysFails (and_seq))
+  (and_seq))
+
+;; ============================================================================
+;; reduceSeqOrAlwaysSucceeds: truncate or_seq after first statically-True child
+;; ============================================================================
+
+;; Existing test: no statically-True child → no truncation
+!(assertEqual
+  (reduceSeqOrAlwaysSucceeds (or_seq A move_forward B))
+  (or_seq A move_forward B))
+
+;; Truncation at turn_left (alwaysSucceeds → True)
+!(assertEqual
+  (reduceSeqOrAlwaysSucceeds (or_seq A turn_left B))
+  (or_seq A turn_left))
+
+;; Truncation at action_success (getActionResult → True)
+!(assertEqual
+  (reduceSeqOrAlwaysSucceeds (or_seq A action_success B))
+  (or_seq A action_success))
+
+;; Non-or_seq operator → passthrough unchanged
+!(assertEqual
+  (reduceSeqOrAlwaysSucceeds (and_seq A action_success B))
+  (and_seq A action_success B))
+
+;; Empty or_seq → passthrough
+!(assertEqual
+  (reduceSeqOrAlwaysSucceeds (or_seq))
+  (or_seq))

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -1187,7 +1187,7 @@
 (= (assertAlphaEqual $A $B)
    (assert (=alpha $A $B)))
 
-; (: unify (-> Expression Expression Expression Expression %Undefined%))
+(: unify (-> Expression Expression Expression Expression %Undefined%))
 (= (unify $space $pattern $then $else)
    (if (is-space $space)
        (let $temp (cut)


### PR DESCRIPTION
## Description

This PR introduces the foundational layer of the MeTTa action reduction engine, porting the core abstractions from the C++ action_reduction.cc pipeline. These files establish the vocabulary, shared helpers, and domain-property interface that the individual reduction rules (coming in subsequent PRs) depend on.
## Additions
## action-vocab.metta — Core operator vocabulary and static success oracle.
- Defines action operators: and_seq, or_seq, exec_seq, action_not, action_bool_if, bool_action_if, contin_action_if, action_action_if, action_while, bool_while
- Defines terminal constants: action_success, action_failure
- Provides a conservative alwaysSucceeds oracle: only turn_left and turn_right are marked as always-succeeding by default. move_forward/step_forward are intentionally excluded — unlike the C++ ant-domain vocabulary where movement succeeds unconditionally, the generic engine keeps them Unknown so domain-specific vocabularies can override without changing reducer code.

## action-helpers.metta — Shared reduction helpers used by all reduction rules.
- getActionResult — Tribool (True/False/Unknown) static analysis of action expressions, covering all operators and recursive into sequences
- getActionResultAnd / getActionResultOr — Folds for and_seq and or_seq static result computation
- flattenAssoc — Flattens nested associative operators in one pass
- pruneAndSeqArgs, pruneOrSeqArgs, pruneExecSeqArgs — Identity-element removal (dropping action_success from and_seq, action_failure from or_seq, both from exec_seq)
- truncateAtAlwaysFails, truncateAtAlwaysSucceeds — Early-exit truncation for deterministic short-circuit reduction
- substituteCondInitInstant — Condition substitution limited to the initial instant of program execution (only first children of sequences, both branches of action_bool_if, condition-only of action_action_if)
- smallestDivisor — Simple factor normalization for modular argument reduction
action-properties.metta — Domain-separated property hooks.
- Defines the interface for: isIdempotent, isReversible/getReversal, isAdditive, isZeroNeutral, isModulo/moduloMin/moduloMax
- Provides conservative default mappings using dummy_* actions so the generic reduction rules can be unit-tested without any domain import
- Clear separation of concerns: domain authors add properties here without modifying the core engine

## reduce-seq-result.metta — Sequence truncation rules.

- reduceSeqAndAlwaysFails — Truncate and_seq children after the first statically-guaranteed failure
- reduceSeqOrAlwaysSucceeds — Truncate or_seq children after the first statically-guaranteed success

## Design decisions
- Conservative defaults: The alwaysSucceeds oracle is intentionally restrictive. Domain-specific facts (e.g., ant-world move_forward always succeeds) belong in domain vocabularies, not in the generic engine. A referenceAntAlwaysSucceeds fact is included in action-vocab.metta for parity testing against the C++ ant baseline.
- Domain-property separation: Property hooks live in their own file so the core reduction rules are domain-independent. Adding a new domain (robotics, grid-world, etc.) only requires updating action-properties.metta.
- Helper extraction: By pulling shared logic into action-helpers.metta, each individual reduction rule file stays focused and testable.
Testing
- The existing test suite (reduct/action-reduct/tests/action-reduction-test.metta) passes against these changes.

### What's next
- Individual reduction rules and the dispatcher will be committed in follow-up PRs to keep each change set focused.

## Motivation and Context
This part of the effort to expand MOSES program generation domain.

## How Has This Been Tested?
Locally tested.
More tests to come as the action-reduction engine takes shape with addition of individual reduction rules and the dispatcher.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
