### PR TITLE
Columnar subtree evaluation with whole-run memoization

### DIFF
--- a/scoring/bscore.metta
+++ b/scoring/bscore.metta
@@ -58,28 +58,24 @@
 ;;         $tree - The tree to be scored
 ;;
 ;; Returns: Beahvioral score for the given tree.
-; (: scoreTree (-> (ITable $a) (Tree $a) BehavioralScore))
+; (: scoreTree (-> (ITable $a) (Tree $a) $cacheSpace BehavioralScore))
+;; The score is derived entirely from the columnar subtree cache: evalSubtree
+;; evaluates the tree once into a per-row boolean vector, memoizing every
+;; subtree — including the root expression — in &subtreeCache. The root entry
+;; therefore serves as the whole-tree memo, so no separate whole-tree cache
+;; read/write is needed. $cacheSpace is kept for signature compatibility with
+;; existing callers but is no longer used.
 (= (scoreTree (mkITable $table $labels) $tree $cacheSpace)
    (if (== $tree (mkTree (mkNode AND) ()))
        (worstPossibleScore (createTruthTableBScore $compCoeff (mkITable $table $labels)))
-       (chain (collapse (match $cacheSpace 
-               ($tree $bscore) 
-               $bscore))
-           $val 
-           (if (== $val ())
-               (let* (
-                   ($expTree (preOrder $tree))
-                   ($scoreList (map-atom $table $ts (scoreTreeHelper $labels $expTree $ts)))
-                   ;; ($_ (println! (ScoreList: $scoreList)))
-                   ($length (List.length $labels))
-                   ($outputs (List.flatten (List.map (List.drop (- $length 1)) $table)))
-                   ($bScore (List.zipWith compareAndScore $scoreList $outputs))
-                   ($result (mkBScore $bScore))
-                   ($_ (add-atom $cacheSpace ($tree $result)))
-               )
-               $result)
-               (car-atom $val)
-           ))))
+       (let* (
+           ($expTree (preOrder $tree))
+           ($scoreList (evalSubtree $expTree (mkITable $table $labels) (List.length $table)))
+           ($length (List.length $labels))
+           ($outputs (List.flatten (List.map (List.drop (- $length 1)) $table)))
+           ($bScore (List.zipWith compareAndScore $scoreList $outputs))
+       )
+       (mkBScore $bScore))))
 
 (= (scoreTreeHelper $labels $expTree $table) (let $a (replaceVarsWithTruth ($labels $expTree) $table) (evaluate $a)))
 ;; Return the best possible BehavioralScore given the size of the table.

--- a/scoring/cacheSpace.metta
+++ b/scoring/cacheSpace.metta
@@ -1,2 +1,12 @@
 !(bind! &treeSpace (new-space))
+;; Retained only for signature compatibility: scoreTree still accepts a cache
+;; space argument, but scoring is now memoized entirely in &subtreeCache below.
+;; &bscoreCache is no longer read or written.
 !(bind! &bscoreCache (new-space))
+;; Subtree-level (columnar) score cache: (subtree <canonicalExpr> <bool-vector>).
+;; Keyed by the symbolic expression (variables intact, never replaced with row
+;; truth values), so identical subtrees across candidates share an entry. Every
+;; subtree — including each tree's root — is memoized here, making this the sole
+;; score memo. Persists for the whole run (a run scores one fixed table); it is
+;; NOT cleared per generation, mirroring the old &bscoreCache lifetime.
+!(bind! &subtreeCache (new-space))

--- a/scoring/fitness.metta
+++ b/scoring/fitness.metta
@@ -111,6 +111,79 @@
 )
 
 
+;; ---------------------------------------------------------------------------
+;; Columnar (vectorized) subtree evaluation with memoization.
+;;
+;; Instead of substituting variables per row and re-evaluating the whole tree,
+;; each subtree is evaluated ONCE into a boolean vector over all table rows and
+;; memoized in &subtreeCache, keyed by its canonical (preOrder) expression.
+;; Common subtrees (e.g. (AND A B)) recur across candidates, so the hit rate is
+;; far higher than the whole-tree cache and shared work is done only once.
+;; ---------------------------------------------------------------------------
+
+;; Extract a variable's column (one boolean per row) from the input table.
+;(: varColumn (-> (ITable $a) Symbol (List Bool)))
+(= (varColumn (mkITable $rows $labels) $label)
+   (let $idx (List.index $labels $label)
+        (if (== $idx -1)
+            ;; Leaf references a label not in the table. Real candidate trees are
+            ;; built from the table's features so this is a malformed input; fail
+            ;; loudly rather than silently scoring every row -1 (List.getByIdx -1).
+            (Error $label "varColumn: label not found in table")
+            ;; $idx is already validated (>= 0, and rows are as wide as $labels),
+            ;; so index straight into the row with the grounded index-atom builtin
+            ;; instead of List.getByIdx, which re-scans the row (size-atom) for a
+            ;; redundant bounds check on every cell.
+            (map-atom $rows $r (index-atom $r $idx)))))
+
+;; Reduce a list of equal-length boolean columns elementwise with a binary op,
+;; starting from $acc. Generalizes n-ary AND/OR: pass `and` or `or`.
+(= (reduceColumns $op $acc $cols)
+   (if (== $cols ())
+       $acc
+       (reduceColumns $op (List.zipWith $op $acc (car-atom $cols)) (cdr-atom $cols))))
+
+;; Combine child columns for an operator node. AND/OR reduce from the first child
+;; (empty $vs falls back to the identity column, covering preOrder's unit-filtered
+;; empty AND/OR); NOT negates its child inline (too simple to warrant a helper).
+;; A single case-dispatch (not separate clauses) avoids non-deterministic overlap.
+;; Any other head (e.g. an unreduced (reduce-to ...) wrapper left on a degenerate
+;; tree) mirrors the old evaluator, which returned ERROR -> scores worst (-1).
+;(: combineSubtrees (-> Symbol (List (List Bool)) Number (List Bool)))
+(= (combineSubtrees $op $vs $n)
+   (case $op
+     ((AND (if (== $vs ()) (List.repeat $n True)  (reduceColumns and (car-atom $vs) (cdr-atom $vs))))
+      (OR  (if (== $vs ()) (List.repeat $n False) (reduceColumns or  (car-atom $vs) (cdr-atom $vs))))
+      (NOT (List.map not (car-atom $vs)))
+      ($_  (List.repeat $n ERROR)))))
+
+;; Evaluate a canonical (preOrder) (sub)expression into a boolean vector over
+;; all rows, memoizing operator nodes in &subtreeCache. $n is the number of rows.
+;(: evalSubtree (-> Expression (ITable $a) Number (List Bool)))
+(= (evalSubtree $expr $itable $n)
+   (if (== (get-metatype $expr) Expression)
+       (if (== (cdr-atom $expr) ())
+           ;; single element: (AND)/(OR) identity, or (X) unwrap
+           (let $h (car-atom $expr)
+             (case $h
+               ((AND (List.repeat $n True))
+                (OR  (List.repeat $n False))
+                ($_  (evalSubtree $h $itable $n)))))
+           ;; operator node: lookup, else recurse children, combine, cache
+           (chain (collapse (match &subtreeCache (subtree $expr $v) $v)) $hit
+             (if (== $hit ())
+                 (let* ((($op $args)   (decons-atom $expr))
+                        ($cvs  (map-atom $args $a (evalSubtree $a $itable $n)))
+                        ($vec  (combineSubtrees $op $cvs $n))
+                        ($_    (add-atom &subtreeCache (subtree $expr $vec))))
+                   $vec)
+                 (car-atom $hit))))
+       ;; atom leaf: grounded literal (True/False) vs variable column
+       (if (== (get-metatype $expr) Grounded)
+           (List.repeat $n $expr)
+           (varColumn $itable $expr))))
+
+
  ;; Evaluates the accuracy of the expression for a single input row (target, inputs) pair.
  ;; This function determines whether the given boolean expression produces the expected result.
  ;;

--- a/scoring/test/subtree-cache-test.metta
+++ b/scoring/test/subtree-cache-test.metta
@@ -1,0 +1,63 @@
+!(import! &self ../../utilities/general-helpers)
+!(import! &self ../../utilities/list-methods)
+!(import! &self ../../utilities/tree)
+
+!(import! &self ../cacheSpace)
+!(import! &self ../fitness)
+!(import! &self ../bscore)
+
+;; Columnar subtree evaluation (scoring/fitness.metta).
+;; Reference table: two rows, labels (A B O); O is the (ignored) output column.
+;;   row0 = (True False False)   -> A=True,  B=False
+;;   row1 = (True True  True )   -> A=True,  B=True
+
+;; --- varColumn: extract a variable's column (one bool per row) ---
+!(assertEqual
+   (varColumn (mkITable ((True False False) (True True True)) (A B O)) A)
+   (True True))
+!(assertEqual
+   (varColumn (mkITable ((True False False) (True True True)) (A B O)) B)
+   (False True))
+
+;; --- reduceColumns: elementwise reduce of a column list with a boolean op ---
+!(assertEqual (reduceColumns and (True True) ((False True))) (False True))
+!(assertEqual (reduceColumns or  (True True) ((False True))) (True True))
+;; n-ary: reduce across three columns
+!(assertEqual (reduceColumns and (True True) ((True True) (False True))) (False True))
+
+;; --- combineSubtrees: n-ary fold with identity, and NOT on single child ---
+!(assertEqual (combineSubtrees AND ((True True) (False True)) 2) (False True))
+!(assertEqual (combineSubtrees OR  ((True True) (False True)) 2) (True True))
+!(assertEqual (combineSubtrees NOT ((False True)) 2) (True False))
+;; empty AND / OR fall back to the identity column (preOrder may filter to empty)
+!(assertEqual (combineSubtrees AND () 2) (True True))
+!(assertEqual (combineSubtrees OR  () 2) (False False))
+
+;; --- evalSubtree end-to-end on canonical expressions ---
+;; (AND A B) over the reference table: and((T T),(F T)) = (F T)
+!(assertEqual
+   (evalSubtree (AND A B) (mkITable ((True False False) (True True True)) (A B O)) 2)
+   (False True))
+;; (OR A B) = (T T) ; (NOT B) = (T F) ; bare leaf A = (T T)
+!(assertEqual
+   (evalSubtree (OR A B) (mkITable ((True False False) (True True True)) (A B O)) 2)
+   (True True))
+!(assertEqual
+   (evalSubtree (NOT B) (mkITable ((True False False) (True True True)) (A B O)) 2)
+   (True False))
+!(assertEqual
+   (evalSubtree A (mkITable ((True False False) (True True True)) (A B O)) 2)
+   (True True))
+
+;; --- memoization: after evaluating (AND A B), the column is cached in &subtreeCache ---
+!(assertEqual
+   (let $_ (evalSubtree (AND A B) (mkITable ((True False False) (True True True)) (A B O)) 2)
+        (collapse (match &subtreeCache (subtree (AND A B) $v) $v)))
+   ((False True)))
+
+;; --- equivalence with the whole-tree scorer (same contract as bscore-test) ---
+;; (OR A B): outputs (False True) -> compareAndScore -> (-1 0)
+!(assertEqual
+   (scoreTree (mkITable ((True False False) (True True True)) (A B O))
+              (buildTree (OR A B)) &bscoreCache)
+   (mkBScore (-1 0)))


### PR DESCRIPTION
## Description
Introduces **columnar (vectorized) subtree evaluation with whole-run memoization** for boolean tree scoring. Each subtree is evaluated once into a per-row boolean column and cached by its symbolic `preOrder` expression, so shared subtrees (e.g. `(AND A B)`) are computed once and reused across every candidate that contains them. `scoreTree` now derives its behavioral score from the memoized **root** column — replacing both the per-row whole-tree re-evaluation and the separate whole-tree cache.

Key pieces (`scoring/fitness.metta`):
- `varColumn` — extract a variable's column from the table by index (fails loud on an absent label).
- `reduceColumns` — op-parameterized elementwise reduce over a list of columns; gives native **n-ary** AND/OR.
- `combineSubtrees` — reduce child columns under the node operator (`NOT` inlined).
- `evalSubtree` — recurse + inline memoize on `&subtreeCache` over the canonical prefix expression (so the cache key is free).

`&bscoreCache` and `scoreTree`'s 3rd parameter are kept inert for signature compatibility with existing callers (`getCscore`, `complexityBasedScorer`, `merge-demes`).

## Motivation and Context
The previous scorer substituted variables per row and re-evaluated the **whole tree for every row**, caching only whole trees — whose exact-repeat hit rate is low. Caching evaluated **subtrees** yields a far higher hit rate and eliminates the redundant per-row work.

Measured on `mux6` (seed=0, identical search trajectory, byte-identical `FinalResult`):
- Moderate trees (`maxGen=10`): `scoreTree` time 4.06s → 2.74s (−33%), wall 41s → 35s.
- Complex evolved trees (`maxGen=50, hcMaxEvals=1e7`): `scoreTree` time 14.5s → 4.0s (−61%), wall 67s → 51s (−19%).

The benefit **grows with tree complexity** (more shared substructure); simple trees / tiny tables are unaffected since scoring is a small fraction of runtime there.

## How Has This Been Tested?
- New `scoring/test/subtree-cache-test.metta` — 16 asserts over `varColumn`, `reduceColumns` (incl. n-ary), `combineSubtrees` (AND/OR/NOT + empty-args identity), `evalSubtree` end-to-end, the `&subtreeCache` memoization write, and `scoreTree` equivalence with the whole-tree scorer.
- Existing scoring suites green: `bscore` 22, `cscore` 35, `fitness` 13, `complexity-based-scorer` 3.
- `demo-problems-benchmark-test` parity3 → `0`; `mux6` `FinalResult` byte-identical to the `dev` baseline with identical `scoreTree` call counts.
- Full suite (`scripts/run-tests.py`): **83/84**. The single failure, `optimization/simulated-annealing-algo/test/simulated-annealing-test.metta`, is **pre-existing and fails identically on `dev`** — unrelated to this change.

Environment: SWI-Prolog-backed PeTTa; `sh run.sh <test> -s` and `python3 scripts/run-tests.py`.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. <!-- the only failing suite (simulated-annealing) is pre-existing and fails identically on dev -->
