### PR TITLE
Restrict feature selection to the exemplar's mispredicted rows (restrict_incorrect)

### DIFF
--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -86,7 +86,7 @@
 (= (ric-blank-xmplr-fts $fts $rows $len)
    (map-atom $rows $row
       (map-atom (genList 0 (- $len 1)) $i
-         (if (ric-is-xmplr-ft $i $fts) False (index-atom $row $i)))))
+         (if (once (is-member $i $fts)) False (index-atom $row $i)))))
 
 (= (ric-is-xmplr-ft $i $fts)
    (> (size-atom (filter-atom $fts $f (== $f $i))) 0))

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -65,27 +65,36 @@
         (representation $nDeme $exemplar (mkITable $table $labels) $ft-selection-algo $prune-exemplar $enforced-fts $scorerType True))
 
 ;; restrictToIncorrect -- classic restrict_incorrect: feed feature selection only
-;; the rows the exemplar mispredicts. Falls back to the full table when it is
-;; already correct everywhere, or when the wrong rows share one output (zero MI).
+;; the rows the exemplar mispredicts, with the exemplar's own columns blanked out.
+;; Falls back to the untouched table when it is already correct everywhere, or when
+;; the wrong rows share one output (zero MI).
 (= (restrictToIncorrect $exemplar (mkITable $table $labels))
    (let* (($expTree (preOrder $exemplar))
           ($len (List.length $labels))
           ($wrongRows (filter-atom $table $row
                         (not (== (scoreTreeHelper $labels $expTree $row)
                                  (index-atom $row (- $len 1)))))))
-     (if (or (== $wrongRows ()) (ric-constant-output $wrongRows $len))
+     (if (ric-constant-output $wrongRows $len)
          (mkITable $table $labels)
-         (mkITable $wrongRows $labels))))
+         (mkITable (ric-blank-xmplr-fts (treeFtsIndices $exemplar $labels) $wrongRows $len) $labels))))
 
-;; True when every row's output column (last column) holds the same value
+;; On the rows the exemplar gets wrong its own features still track the output, so
+;; feature selection would just hand back the features the exemplar already uses and
+;; the search would never gain a new one. Classic blanks those columns rather than
+;; dropping them: a constant column carries no mutual information so it is never
+;; selected, and every remaining column keeps its index.
+(= (ric-blank-xmplr-fts $fts $rows $len)
+   (map-atom $rows $row
+      (map-atom (genList 0 (- $len 1)) $i
+         (if (ric-is-xmplr-ft $i $fts) False (index-atom $row $i)))))
+
+(= (ric-is-xmplr-ft $i $fts)
+   (> (size-atom (filter-atom $fts $f (== $f $i))) 0))
+
+;; True when the output column (last column) holds at most one distinct value.
+;; The empty row set counts as constant, which covers the correct-everywhere case.
 (= (ric-constant-output $rows $len)
-   (ric-all-same (map-atom $rows $r (index-atom $r (- $len 1)))))
-(= (ric-all-same $xs)
-   (if (== $xs ()) True (ric-all-eq (car-atom $xs) (cdr-atom $xs))))
-(= (ric-all-eq $h $xs)
-   (if (== $xs ())
-       True
-       (if (== (car-atom $xs) $h) (ric-all-eq $h (cdr-atom $xs)) False)))
+   (<= (size-atom (unique-atom (map-atom $rows $r (index-atom $r (- $len 1))))) 1))
 
 (= (representation
 ;; Boolean representation constructor with optional logical disc probing

--- a/representation/representation.metta
+++ b/representation/representation.metta
@@ -64,6 +64,29 @@
         )
         (representation $nDeme $exemplar (mkITable $table $labels) $ft-selection-algo $prune-exemplar $enforced-fts $scorerType True))
 
+;; restrictToIncorrect -- classic restrict_incorrect: feed feature selection only
+;; the rows the exemplar mispredicts. Falls back to the full table when it is
+;; already correct everywhere, or when the wrong rows share one output (zero MI).
+(= (restrictToIncorrect $exemplar (mkITable $table $labels))
+   (let* (($expTree (preOrder $exemplar))
+          ($len (List.length $labels))
+          ($wrongRows (filter-atom $table $row
+                        (not (== (scoreTreeHelper $labels $expTree $row)
+                                 (index-atom $row (- $len 1)))))))
+     (if (or (== $wrongRows ()) (ric-constant-output $wrongRows $len))
+         (mkITable $table $labels)
+         (mkITable $wrongRows $labels))))
+
+;; True when every row's output column (last column) holds the same value
+(= (ric-constant-output $rows $len)
+   (ric-all-same (map-atom $rows $r (index-atom $r (- $len 1)))))
+(= (ric-all-same $xs)
+   (if (== $xs ()) True (ric-all-eq (car-atom $xs) (cdr-atom $xs))))
+(= (ric-all-eq $h $xs)
+   (if (== $xs ())
+       True
+       (if (== (car-atom $xs) $h) (ric-all-eq $h (cdr-atom $xs)) False)))
+
 (= (representation
 ;; Boolean representation constructor with optional logical disc probing
             $nDeme
@@ -84,7 +107,7 @@
                  ;; ($_ (println! "before featureSelector"))
                  ($ft-set-pop (if (== $ft-selection-algo None)
                                   ((genList 0 (- (List.length $labels) 2))) ;; Applying all labels as features
-                                  (featureSelector $ft-selection-algo (mkITable $table $labels) 0.0 $exemplar 2 2 False () False 2 False ja $nDeme 50.0 1.0 0.5 1.0 True $scorerType)) ;; applies the right parameteres for feature selection based on selected selection algorithm 
+                                  (featureSelector $ft-selection-algo (restrictToIncorrect $exemplar (mkITable $table $labels)) 0.0 $exemplar 2 2 False () False 2 False ja $nDeme 50.0 1.0 0.5 1.0 True $scorerType)) ;; FS on the exemplar's mispredicted rows (classic restrict_incorrect, with full-table fallback)
                  )
                  ;; ($_ (println! (Selected Features after feature Selection $ft-set-pop)))
                  ($exemplar-arg-seq                                           ;; apply exemplar feature pruning

--- a/representation/tests/representation-test.metta
+++ b/representation/tests/representation-test.metta
@@ -31,6 +31,8 @@
 !(import! &self ../../representation/build-knobs)
 !(import! &self ../../representation/knob-mapper)
 
+;; restrictToIncorrect runs the exemplar over each row, so `evaluate` must be defined
+!(import! &self ../../scoring/fitness)
 !(import! &self ../../scoring/bscore)
 !(import! &self ../../scoring/cscore)
 
@@ -304,12 +306,59 @@
 ;; ;      (mkTree (mkNode OR) (cons (mkTree (mkNode AND) (cons (mkTree (mkNode C) ()) (cons (mkNullVex (cons (mkTree (mkNode OR) (cons (mkTree (mkNode A) ()) (cons (mkTree (mkNode B) ()) ()))) ())) (cons (mkNullVex (cons (mkTree (mkNode OR) (cons (mkTree (mkNode NOT) (cons (mkTree (mkNode A) ()) ())) (cons (mkTree (mkNode B) ()) ()))) ())) (cons (mkNullVex (cons (mkTree (mkNode B) ()) ())) (cons (mkNullVex (cons (mkTree (mkNode A) ()) ())) ())))))) (cons (mkNullVex (cons (mkTree (mkNode AND) (cons (mkTree (mkNode A) ()) (cons (mkTree (mkNode B) ()) ()))) ())) (cons (mkNullVex (cons (mkTree (mkNode AND) (cons (mkTree (mkNode NOT) (cons (mkTree (mkNode A) ()) ())) (cons (mkTree (mkNode B) ()) ()))) ())) (cons (mkNullVex (cons (mkTree (mkNode B) ()) ())) (cons (mkNullVex (cons (mkTree (mkNode A) ()) ())) ()))))))))
 
 (= (ttable)
-    (mkITable 
+    (mkITable
         (cons (cons False (cons False (cons True (cons True (cons True ())))))
         (cons (cons True (cons False (cons False (cons True (cons True ())))))
         (cons (cons False (cons True (cons False (cons True (cons False ())))))
         (cons (cons False (cons False (cons False (cons True (cons False ()))))) ()))))
         (cons A (cons B (cons C (cons D (cons Output ())))))))
+
+;; restrictToIncorrect -- the three cases classic MOSES describes in feature_selector.cc
+
+;; Out = XOR(A B)
+(= (xorTable)
+    (mkITable
+        (cons (cons False (cons False (cons False ())))
+        (cons (cons False (cons True  (cons True  ())))
+        (cons (cons True  (cons False (cons True  ())))
+        (cons (cons True  (cons True  (cons False ()))) ()))))
+        (cons A (cons B (cons Out ())))))
+
+;; Out = A
+(= (idTable)
+    (mkITable
+        (cons (cons False (cons False (cons False ())))
+        (cons (cons False (cons True  (cons False ())))
+        (cons (cons True  (cons False (cons True  ())))
+        (cons (cons True  (cons True  (cons True  ()))) ()))))
+        (cons A (cons B (cons Out ())))))
+
+;; Out = OR(A B)
+(= (orTable)
+    (mkITable
+        (cons (cons False (cons False (cons False ())))
+        (cons (cons False (cons True  (cons True  ())))
+        (cons (cons True  (cons False (cons True  ())))
+        (cons (cons True  (cons True  (cons True  ()))) ()))))
+        (cons A (cons B (cons Out ())))))
+
+(= (xmplrA) (mkTree (mkNode A) ()))
+(= (xmplrAndAB) (mkTree (mkNode AND) (cons (mkTree (mkNode A) ()) (cons (mkTree (mkNode B) ()) ()))))
+
+;; A mispredicts rows 2 and 4, which carry different outputs, so only those rows
+;; reach feature selection. Column A is blanked out because the exemplar owns it.
+!(assertEqual (restrictToIncorrect (xmplrA) (xorTable))
+    (mkITable
+        (cons (cons False (cons True  (cons True  ())))
+        (cons (cons False (cons True  (cons False ()))) ()))
+        (cons A (cons B (cons Out ())))))
+
+;; A is right on every row, so there is nothing to restrict to.
+!(assertEqual (restrictToIncorrect (xmplrA) (idTable)) (idTable))
+
+;; (AND A B) is only ever wrong on rows whose output is True. Those rows carry no
+;; mutual information with the output, so the full table is kept.
+!(assertEqual (restrictToIncorrect (xmplrAndAB) (orTable)) (orTable))
 
 
 ;; !(assertEqual (representation 


### PR DESCRIPTION
## What
Ports classic MOSES `restrict_incorrect` (`feature_selector.cc`). Before feature selection runs, the input table is restricted to the rows the current exemplar mispredicts, so selection favors features that correlate with the exemplar's errors. Falls back to the full table when the exemplar is already correct everywhere, or when the wrong rows share one output value (zero MI).

## Status

Lands the mechanism only. With the `sim` selector it's neutral on `mux6`/`parity3` (classic `simple` also returns a single feature set, so there's no population to differentiate). The payoff needs a population-producing selector (`hc`), which is broken and tracked under a separate issue; once that lands, we can measure whether this improves result quality.

## Testing

`runDemoProblem` with `fsAlgo=sim` on `parity3` runs the new path end to end, reduces cleanly, and returns a valid result. The `fsAlgo=None` path is unchanged.
