### PR TITLE
feat: store input tables in column-major format

### DIFF
--- a/deme/score-deme.metta
+++ b/deme/score-deme.metta
@@ -73,32 +73,30 @@
 ;; Applies mutual information based scoring to a list of Instances.
 ;; Params:
 ;;   (cons (mkInst $i) $is): List of Instances.
-;;   (mkITable $rows $labels): Input table with rows and labels.
+;;   (mkITable $table $labels): Input table with rows and labels.
 ;;   $listOfScoredInst: Accumulator for Scored Instances.
 ;; Returns:
 ;;   List of Scored Instances with mutual information based scores.
 ; (: applyMutualInformationBasedScore (-> (List Instance) (ITable $a) (List (ScoredInstance Cscore)) Number (List (ScoredInstance Cscore))))
-(= (applyMutualInformationBasedScore () (mkITable $rows $labels) $miConfi $listOfScoredInst) 
-   ;; (trace! (Returning $listOfScoredInst)
-           $listOfScoredInst
-   ;; )
-)
-(= (applyMutualInformationBasedScore (cons (mkInst $i) $is) (mkITable $rows $labels) $miConf $listOfScoredInst)
+(= (applyMutualInformationBasedScore () (mkITable $table $labels) $miConfi $listOfScoredInst)
+   $listOfScoredInst)
+   
+(= (applyMutualInformationBasedScore (cons (mkInst $i) $is) (mkITable $table $labels) $miConf $listOfScoredInst)
 (let*
 (
-    ($targetColumn (Table.getOutputColumn (mkITable $rows $labels)))
+    ($targetColumn (Table.getOutputColumn (mkITable $table $labels)))
     ($indices (bitsToIndices $i 0 ()))
-    ($zippedCols (zipColumn $indices $rows))
+    ($zippedCols (zipColumn $indices $table))
+
     ($score (mutualInformation $zippedCols $targetColumn))
-    
-    ; in the c++ it also calculates the confidence too
-    ($confidence (calculateConfidence (size-atom $indices) (List.length $rows) $miConf))
+
+    ;; number of samples = length of any column
+    ($confidence (calculateConfidence (size-atom $indices) (List.length (Table.getColumn 0 $table)) $miConf))
     ($scoreConfi (* $score $confidence))
     ($scoredInst (mkSInst (mkPair (mkInst $i) $scoreConfi)))
     ($uListofScoredInst (cons $scoredInst $listOfScoredInst))
 )
-(applyMutualInformationBasedScore $is (mkITable $rows $labels) $miConf $uListofScoredInst)))
-
+(applyMutualInformationBasedScore $is (mkITable $table $labels) $miConf $uListofScoredInst)))
 
 ;; similar to the above 'transform' but uses the mutualInformation based scoring for features selection
 ;; Scores each instance in an InstanceSet. 

--- a/deme/tests/score-deme-test.metta
+++ b/deme/tests/score-deme-test.metta
@@ -88,11 +88,12 @@
 (= (ttable1) (mkITable (cons (cons True (cons False (cons True ())))
                         (cons (cons True (cons True  (cons True ()))) ())) 
                         (cons A (cons B (cons O ())))))
+
 (= (ttable2) (mkITable
-                    (cons (cons True (cons True (cons True (cons True ()))))
+                    (cons (cons True (cons True (cons False (cons False ()))))
+                    (cons (cons True (cons False (cons True (cons False ()))))
                     (cons (cons True (cons False (cons False (cons False ()))))
-                    (cons (cons False (cons True (cons False (cons False ()))))
-                    (cons (cons False (cons False (cons False (cons False ())))) ()))))
+                    (cons (cons True (cons False (cons False (cons False ())))) ()))))
                     (cons A (cons B (cons C (cons output ()))))))
 ;; NOTE: All the instances in the deme don't include lsk1 (or they all start with '0') because we are testing it using ttable2. 
 ;;       ttable2 is a truth table which doesn't have a 'D' column.
@@ -104,7 +105,8 @@
       (cons (mkInst (cons 0 (cons 0 (cons 2 ())))) (cons (mkInst (cons 0 (cons 0 (cons 1 ())))) (cons (mkInst (cons 0 (cons 2 (cons 2 ())))) ())))
       (ttable2)
       2.0)
-   (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 2 ())))) (mkCscore -2 3 1.5 0.0 -3.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 1 ())))) (mkCscore 0 3 1.5 0.0 -1.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 2 (cons 2 ())))) (mkCscore -2 4 2.0 0.0 -4.0))) ()))))
+   (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 2 ())))) (mkCscore 0 3 1.5 0.0 -1.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 1 ())))) (mkCscore -2 3 1.5 0.0 -3.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 2 (cons 2 ())))) (mkCscore 0 4 2.0 0.0 -2.0))) ()))))
+
 
 !(assertEqual
    (applyComplexityBasedScore 
@@ -123,7 +125,7 @@
    (mkDemeId "1")
    (ttable2)
    2.0)
-   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 2 ())))) (mkCscore -2 3 1.5 0.0 -3.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 1 ())))) (mkCscore 0 3 1.5 0.0 -1.5))) ()))))
+   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 2 ())))) (mkCscore 0 3 1.5 0.0 -1.5))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 1 ())))) (mkCscore -2 3 1.5 0.0 -3.5))) ()))))
 
 ; The these test cases are commented out because they behave non deterministically when running all the 3 representation together 
 ;; but runs correctly when running them separately !!
@@ -134,7 +136,7 @@
    (mkDemeId "1")
    (ttable2)
    1)
-   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -4 0 0.0 0.0 -4.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 1 ())))) (mkCscore 0 3 3.0 0.0 -3.0))) ())))) 
+   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -4 0 0.0 0.0 -4.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 1 ())))) (mkCscore -2 3 3.0 0.0 -5.0))) ())))) 
 
 ;; Testcase for the bitsToIndices
 !(assertEqual (bitsToIndices (cons 1 (cons 0 (cons 1 (cons 0 ())))) 0 ()) (0 2))
@@ -201,3 +203,4 @@
 !(assertEqual (transform
    (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 1 (cons 1 ()))) -1.0e308)) ()))
    (StrategyRep) (mkDemeId "1") (1) 3.5) (mkSInstSet ((mkSInst (mkPair (mkInst (1 1)) (mkCscore -1.0 2 0.5714285714285714 0.0 -1.5714285714285714))))))
+

--- a/feature-selection/feature-selection-helpers.metta
+++ b/feature-selection/feature-selection-helpers.metta
@@ -20,37 +20,36 @@
             (List.uniqueValuesCount $xs $new-tuple-added))))
 
 ; (: Table.getColumn (-> Number (List (List $a)) (List $a)))
-(= (Table.getColumn $i ()) ())
-(= (Table.getColumn $i (cons $row $rest))
-    (cons (List.at $i $row) (Table.getColumn $i $rest)))
-; ;; Table.pop        -- gets and removes a column from the current ttable structure
-; ;;                  -- returns the remaining table and the culumn asked for
-(= (Table.pop $i ()) ())
-(= (Table.pop $i (cons $row $rest))
-    (let (cons $d $ds) $row
-        (if (== $i 0)
-            (cons $ds (Table.pop $i $rest))
-            (cons (cons $d (List.pop (- $i 1) $ds)) (Table.pop $i $rest)))))
-; removes the first column from table
-; ; (: Table.pop (-> (List (List $a)) (List (List $a))))
-; (= (Table.pop $rows)
-;     (unify $rows () ()
-;         (unify $rows (cons (cons $d $ds) $rest)
-;             (cons $ds (Table.pop $rest)) ())))
+(= (Table.getColumn $i $table)
+    (if (== $table ())
+         ()
+       (List.at $i $table)))
 
-;; returns the last column of the table
+;; Table.pop        -- gets and removes a column from the current ttable structure
+;;                  -- returns the remaining table
+(= (Table.pop $i $table)
+    (if (== $table ())
+         ()
+         (List.pop $i $table)))
+
+;; Removes the first column from a column-major table.
+; (: Table.pop (-> (List (List $a)) (List (List $a))))
+(= (Table.pop $table)
+    (List.pop 0 $table))
+
+;;  returns the last column of the table
 ; (: Table.getOutputColumn (-> ITable (List $a)))
 (= (Table.getOutputColumn (mkITable $table $labels))
-    (chain (List.length $labels) $colNum 
-    (chain (Table.getColumn (- $colNum 1) $table) $oc   
-    $oc  ))
-)
+    (chain (List.length $labels) $colNum
+        (Table.getColumn (- $colNum 1) $table)))
+
 
 ;;;;;;;;;;;;;;
 ;; Transpose;;
 ;;;;;;;;;;;;;;
 ; (: Table._transposeHelper (-> (List Number) (List (List $a)) (List (List $a))))
 (= (Table._transposeHelper () $table) ())
+
 (= (Table._transposeHelper (cons $i $rest) $table)
     (cons (Table.getColumn $i $table)
           (Table._transposeHelper $rest $table)))
@@ -236,7 +235,7 @@
             (if (= $datarows (cons $row $rows))
                 (chain (map-atom $indices $i (List.at $i $row)) $dataTuple
                     (cons $dataTuple (zipColumn $indices $rows)))
-                ()))))
+                 ()))))
 
 ;; return marginal probabilities as tuple (p1 p2)
 ; (: marginalProbs (-> Number Expression Expression))

--- a/feature-selection/feature-selection-helpers.metta
+++ b/feature-selection/feature-selection-helpers.metta
@@ -221,9 +221,10 @@
                     ;; feature MI calculation
             (chain (zipColumn $featureIndices $rows) $jointColumn
                 (chain (mutualInformation $jointColumn $targetColumn) $miScore
-                                                                                            ;; the default confidence scaling parameter
-                        (chain (calculateConfidence (size-atom $featureIndices) (List.length $rows) 50.0) $confidence
-                                (* $miScore $confidence)))))))
+                    (chain (List.length $targetColumn) $rowCount ;; Use the number of examples for confidence scaling.
+
+                        (chain (calculateConfidence (size-atom $featureIndices) $rowCount 50.0) $confidence
+                                (* $miScore $confidence))))))))
 
 (= (cachedMutualInformation $itable $featureIndices)
     (lruCache (param defaultCacheSize) ((calculateMutualInformation) ($itable $featureIndices))))

--- a/feature-selection/feature-selection-helpers.metta
+++ b/feature-selection/feature-selection-helpers.metta
@@ -228,15 +228,22 @@
 
 (= (cachedMutualInformation $itable $featureIndices)
     (lruCache (param defaultCacheSize) ((calculateMutualInformation) ($itable $featureIndices))))
-; (: zipColumn (-> Expression (List (List $a)) (List $a)))        
-(= (zipColumn $indices $datarows)
+
+;; Build row-wise tuples from selected columns in a column-major table.
+; (: zipColumn (-> Expression (List (List $a)) (List $a)))
+(= (zipColumn $indices $table)
     (if (== $indices ())
         ()
-        (unify $datarows () ()
-            (if (= $datarows (cons $row $rows))
-                (chain (map-atom $indices $i (List.at $i $row)) $dataTuple
-                    (cons $dataTuple (zipColumn $indices $rows)))
-                 ()))))
+        (chain (map-atom $indices $i (Table.getColumn $i $table)) $columns
+            (chain (List.length (List.at 0 $columns)) $rowCount
+                (zipColumnHelper $columns (List.range 0 $rowCount))))))
+
+;; (: zipColumnHelper (-> (List (List $a)) (List Number) (List $a)))
+(= (zipColumnHelper $columns ()) ())
+
+(= (zipColumnHelper $columns (cons $rowIdx $rest))
+    (chain (map-atom $columns $column (List.at $rowIdx $column)) $dataTuple
+        (cons $dataTuple (zipColumnHelper $columns $rest))))
 
 ;; return marginal probabilities as tuple (p1 p2)
 ; (: marginalProbs (-> Number Expression Expression))

--- a/feature-selection/feature-selection-helpers.metta
+++ b/feature-selection/feature-selection-helpers.metta
@@ -216,15 +216,14 @@
 
 
 (= (calculateMutualInformation (mkITable $rows $labels) $featureIndices)
-    (chain (- (List.length $labels) 1) $targetIndex
-        (chain (Table.getColumn $targetIndex $rows) $targetColumn
-                    ;; feature MI calculation
-            (chain (zipColumn $featureIndices $rows) $jointColumn
-                (chain (mutualInformation $jointColumn $targetColumn) $miScore
-                    (chain (List.length $targetColumn) $rowCount ;; Use the number of examples for confidence scaling.
-
-                        (chain (calculateConfidence (size-atom $featureIndices) $rowCount 50.0) $confidence
-                                (* $miScore $confidence))))))))
+    (let* (
+           ($targetIndex (- (List.length $labels) 1))
+           ($targetColumn (Table.getColumn $targetIndex $rows))
+           ($jointColumn (zipColumn $featureIndices $rows))
+           ($miScore (mutualInformation $jointColumn $targetColumn))
+           ($confidence (calculateConfidence (size-atom $featureIndices) (List.length $targetColumn) 50.0))
+          )
+          (* $miScore $confidence)))
 
 (= (cachedMutualInformation $itable $featureIndices)
     (lruCache (param defaultCacheSize) ((calculateMutualInformation) ($itable $featureIndices))))
@@ -234,14 +233,16 @@
 (= (zipColumn $indices $table)
     (if (== $indices ())
         ()
-        (chain (map-atom $indices $i (Table.getColumn $i $table)) $columns
-            (chain (List.length (List.at 0 $columns)) $rowCount
-                (zipColumnHelper $columns (List.range 0 $rowCount))))))
+        (let* (
+               ($columns (map-atom $indices $i (Table.getColumn $i $table)))
+              )
+              (zipColumnHelper $columns (List.range 0 (List.length (List.at 0 $columns)))))))
 
 ;; (: zipColumnHelper (-> (List (List $a)) (List Number) (List $a)))
 (= (zipColumnHelper $columns ()) ())
 
 (= (zipColumnHelper $columns (cons $rowIdx $rest))
+
     (chain (map-atom $columns $column (List.at $rowIdx $column)) $dataTuple
         (cons $dataTuple (zipColumnHelper $columns $rest))))
 

--- a/feature-selection/similarity-scorers.metta
+++ b/feature-selection/similarity-scorers.metta
@@ -19,7 +19,7 @@
 ;; mutualInformationBtwSets  -- calculates the MI between feature sets by using entropy values        
 (= (mutualInformationBtwSets $set1 $set2 (mkITable $table $labels))
     (let* (($union (union-atom $set1 $set2))
-            ($len (List.length $table))                                                                                   ;; total number of rows
+            ($len (List.length (Table.getColumn 0 $table)))                                                                                   ;; total number of rows
             (($set1-zip $set2-zip $union-zip) (map-atom ($set1 $set2 $union) $set (zipColumn $set $table))) 
             (($zip1-count $zip2-count $union-count) (map-atom ($set1-zip $set2-zip $union-zip) $zip (List.uniqueValuesCount $zip ())))
             (($e1 $e2 $eu) (map-atom ($zip1-count $zip2-count $union-count) $count (entropy $count $len 0))))

--- a/feature-selection/simple.metta
+++ b/feature-selection/simple.metta
@@ -13,7 +13,7 @@
 
         (chain (py-call (random.randint 0 2147483647)) $seed                                        ;; random seed to break ties between equally-scored features
         (chain (List.length $labels) $colNum
-            (chain (List.length $table) $rowNum
+            (chain (List.length (Table.getColumn 0 $table)) $rowNum
                 (chain (Table.getColumn (- $colNum 1) $table) $oc                                  ;; get the output column
                     (chain (selectorIterator $th $rowNum $oc $labels $table 0 $seed $acc) $selected-features  ;; the output format might need to change into sth like ((1) (2) (3) (4))
                         (chain (if $expDist                                                                        ;; this is the actual selection after the scoring
@@ -36,7 +36,7 @@
         (chain (Table.getColumn 0 $dataRows) $if
         (chain (Table.pop 0 $dataRows) $rem-table                            ;; remove the first column -- better than carrying around the whole table
         (chain (mutualInformation $if $oc) $mi
-            (chain (calculateConfidence (size-atom $if) (List.length $dataRows) 50.0) $confidence
+            (chain (calculateConfidence (size-atom $if) $rowNum 50.0) $confidence
                 (chain (* $mi $confidence) $actualScore
                     (if (>= $actualScore $th)
                         (chain (eval (insertPair > (featureSet< $seed) ($actualScore ($counter)) $acc)) $new-acc   ;; seeded tie-break for equal scores (matches selectTopFts / OpenCog)

--- a/feature-selection/tests/feature-selection-helpers-test.metta
+++ b/feature-selection/tests/feature-selection-helpers-test.metta
@@ -25,11 +25,12 @@
 !(assertEqual (pairMax (1 x) (9 y)) (9 y))
 
 ;; Test
-!(test (takeN 0 (True False True)) ())
+!(assertEqual (takeN 0 (True False True)) ())
 !(assertEqual (takeN 2 (True False True)) (True False))
 !(assertEqual (takeN 5 (True False)) (True False))
 !(assertEqual (takeN 3 ()) ())
-; ;; Test
+
+;; Test
 !(assertEqual (List.uniqueValuesCount () ()) ()) ;; ?? is this really what I expect? if the list is empty
 !(assertEqual (List.uniqueValuesCount (cons True (cons False (cons True ()))) ()) ((True 2) (False 1)))
 !(assertEqual (List.uniqueValuesCount (cons False (cons False (cons True (cons True (cons True ()))))) ()) ((False 2) (True 3)))
@@ -38,18 +39,19 @@
 ;; Test
 (= (itable) 
     (cons (cons True (cons False (cons True ()))) 
-    (cons (cons False (cons True (cons False ()))) ())))
+    (cons (cons False (cons True (cons False ()))) 
+    (cons (cons False (cons False (cons True ()))) ()))))
 
 !(assertEqual (Table.getColumn 0 ()) ())
-!(assertEqual (Table.getColumn 0 (itable)) (cons True (cons False ())))
-!(assertEqual (Table.getColumn 1 (itable)) (cons False (cons True ())))
-!(assertEqual (Table.getColumn 2 (itable)) (cons True (cons False ())))
+!(assertEqual (Table.getColumn 0 (itable)) (cons True (cons False (cons True ()))))
+!(assertEqual (Table.getColumn 1 (itable)) (cons False (cons True (cons False ()))))
+!(assertEqual (Table.getColumn 2 (itable)) (cons False (cons False (cons True ()))))
 
 ;; Testcase for Table.getOutputColumn
 !(assertEqual
-    (Table.getOutputColumn (mkITable (cons (cons True (cons False (cons False ()))) 
-                                      (cons (cons False (cons True (cons False ()))) 
-                                      (cons (cons True (cons True (cons False ()))) 
+    (Table.getOutputColumn (mkITable (cons (cons True (cons False (cons True ()))) 
+                                      (cons (cons False (cons True (cons True ()))) 
+                                      (cons (cons False (cons False (cons False ()))) 
                                       ())))
                                       (cons A (cons B (cons O ())))))                              
     (cons False (cons False (cons False ()))))
@@ -57,8 +59,8 @@
 ;; Test
 !(assertEqual (Table.pop 0 ()) ())
 !(assertEqual (Table.pop 0 (itable)) 
-        (cons (cons False (cons True ())) 
-        (cons (cons True (cons False ())) ())))
+        (cons (cons False (cons True (cons False ())))
+        (cons (cons False (cons False (cons True ()))) ())))
 
 
 ;; Test lexicographic ordering of featureSets
@@ -113,22 +115,24 @@
 !(assertEqual (sortPairs pairMax ((0.7 (M)) (0.4 (N)) (0.9 (O)) (0.1 (P))) 3 ()) ((0.9 (O)) (0.7 (M)) (0.4 (N))))
 
 (= (table2) 
-            (cons (cons True (cons True (cons False (cons True (cons True ())))))
-            (cons (cons True (cons False (cons False (cons True (cons True ())))))
-            (cons (cons False (cons True (cons False (cons True (cons False ())))))
-            (cons (cons False (cons False (cons False (cons True (cons False ()))))) ())))))
+            (cons (cons True (cons True (cons False (cons False ()))))
+            (cons (cons True (cons False (cons True (cons False ()))))
+            (cons (cons False (cons False (cons False (cons False ()))))
+            (cons (cons True (cons True (cons True (cons True ()))))
+             (cons (cons True (cons True (cons False (cons False ())))) ()))))))
 
 !(assertEqual (zipColumn (1 3) (table2)) (cons (True True) (cons (False True) (cons (True True) (cons (False True) ())))))
 !(assertEqual (zipColumn (0 1 4) (table2)) (cons (True True True) (cons (True False True) (cons (False True False) (cons (False False False) ())))))
 !(assertEqual (zipColumn (2) (table2)) (cons (False) (cons (False) (cons (False) (cons (False) ()))))) 
 
-; !(assertEqual (let $r (logMath 2 8) (- $r 3))  0.0)
-; !(assertEqual (let $r (logMath 10 1000) (- $r 3))  0.0)
+!(assertEqual (let $r (logMath 2 8) (- $r 3)) 0.0)
+; !(assertEqual (let $r (logMath 10 1000) (- $r 3)) 0.0)
 
 (= (table1) 
     (mkITable
-        (cons (cons True (cons False (cons True ()))) 
-        (cons (cons False (cons True (cons False ()))) ()))
+        (cons (cons True (cons False ())) 
+        (cons (cons False (cons True  ())) 
+        (cons (cons True (cons False  ())) ())))
         (cons A (cons B (cons O ())))))
 
 !(assertEqual (filterTable (0) (table1)) 
@@ -138,13 +142,12 @@
                             (cons B (cons O ())))) 
 !(assertEqual (filterTable (1) (table1)) 
                     (mkITable 
-                            (cons (cons True (cons True ())) 
-                            (cons (cons False (cons False ())) ())) 
+                            (cons (cons True (cons False ())) 
+                            (cons (cons True (cons False ())) ())) 
                             (cons A (cons O ())))) 
 !(assertEqual (filterTable (0 1) (table1)) 
                     (mkITable 
-                            (cons (cons True ())
-                            (cons (cons False ()) ()))
+                            (cons (cons True (cons False  ())) ())
                             (cons O ())))
 
 ;; test for incremental selection Utility functions
@@ -182,19 +185,9 @@
 !(assertEqual (readjustIndices ((0.4 (1)) (0.5 (1 2))) (cons A (cons C (cons D ()))) (cons A (cons B (cons C (cons D ()))))) ((0.4 (2)) (0.5 (2 3))))
 
 
-; Test of CalculateConfidence
-!(assertEqual 
-   (let* (
-       ($conf1 (calculateConfidence 1 10 0.1))
-       ($conf2 (calculateConfidence 2 10 0.1))
-     )
-     (< $conf1 $conf2)) True)  ;; more features → higher confidence
-
-!(assertEqual
-   (let* (
-       ($conf2 (calculateConfidence 2 10 0.1))
-       ($conf3 (calculateConfidence 2 20 0.1))
-     )
-     (< $conf2 $conf3)) True)  ;; bigger dataset → higher confidence
-
+;; Test of CalculateConfidence
+!(assertEqual (< (calculateConfidence 1 10 0.1) (calculateConfidence 2 10 0.1)) True)  ;; more features → higher confidence
+!(assertEqual (< (calculateConfidence 2 10 0.1) (calculateConfidence 2 20 0.1)) True)  ;; bigger dataset → higher confidence
 !(assertEqual (calculateConfidence 1 0 0.1) 0.0)  ;; No features -> confidence 0
+
+

--- a/feature-selection/tests/incremental-test.metta
+++ b/feature-selection/tests/incremental-test.metta
@@ -9,31 +9,32 @@
 
 (= (andTable) 
    (mkITable
-     (cons (cons True (cons True (cons True ())))
-     (cons (cons True (cons False (cons False ())))
-     (cons (cons False (cons True (cons False ())))
-     (cons (cons False (cons False (cons False ()))) ()))))
+     (cons (cons True (cons True (cons False (cons False ()))))
+     (cons (cons True (cons False (cons True (cons False ()))))
+     (cons (cons True  (cons False  (cons False (cons False ())))) ())))
      (cons A (cons B (cons Output ())))))
+
 
 (= (complexTable) 
     (mkITable 
-        (cons (cons False (cons False (cons True (cons True (cons True ())))))
-        (cons (cons True (cons False (cons False (cons True (cons True ())))))
-        (cons (cons False (cons True (cons False (cons True (cons False ())))))
-        (cons (cons False (cons False (cons False (cons True (cons False ()))))) ()))))
+        (cons (cons False (cons True (cons False (cons False ()))))
+        (cons (cons False (cons False (cons True (cons False ()))))
+        (cons (cons True (cons False (cons False (cons False ()))))
+        (cons (cons True (cons True (cons True (cons True ())))) 
+        (cons (cons True (cons True (cons False (cons False ()))))())))))
         (cons A (cons B (cons C (cons D (cons Output ())))))))
 
+
 (= (xorTable) (mkITable
-    (cons (cons True  (cons True  (cons False ())))
-    (cons (cons True  (cons False (cons True  ())))
-    (cons (cons False (cons True  (cons True  ())))
-    (cons (cons False (cons False (cons False ()))) ()))))
+    (cons (cons True (cons True (cons False (cons False ()))))
+    (cons (cons True (cons False (cons True (cons False ()))))
+    (cons (cons False (cons True  (cons True (cons False ())))) ())))
     (cons A (cons B (cons Output ())))))
 
 (= (redundantTable) (mkITable 
-    (cons (cons True  (cons True  (cons True  ())))
-    (cons (cons True  (cons True  (cons True  ())))
-    (cons (cons False (cons False (cons False ())))
+    (cons (cons True  (cons True  (cons False (cons False ()))))
+    (cons (cons True  (cons True  (cons False (cons False ()))))
+    (cons (cons True (cons True (cons False (cons False ()))))
     (cons (cons False (cons False (cons False ()))) ()))))
     (cons A (cons B (cons Output ())))))
 

--- a/feature-selection/tests/similarity-scorers-test.metta
+++ b/feature-selection/tests/similarity-scorers-test.metta
@@ -5,10 +5,11 @@
 
 (= (ttable) 
     (mkITable 
-        (cons (cons False (cons False (cons True (cons True (cons True ())))))
-        (cons (cons True (cons False (cons False (cons True (cons True ())))))
-        (cons (cons False (cons True (cons False (cons True (cons False ())))))
-        (cons (cons False (cons False (cons False (cons True (cons False ()))))) ()))))
+        (cons (cons False (cons True (cons False (cons False ()))))
+        (cons (cons False (cons False (cons True (cons False ()))))
+        (cons (cons True (cons False (cons False (cons False ()))))
+        (cons (cons True (cons True (cons True (cons True ())))) 
+        (cons (cons True (cons True (cons False (cons False ())))) ())))))
         
         (cons A (cons B (cons C (cons D (cons Output ())))))))
 
@@ -17,6 +18,6 @@
 !(assertEqual (jaccardIndex (A B) (B)) 0.5) 
 !(assertEqual (jaccardIndex (A B) (B A)) 1) 
 
-!(assertEqual (py-call ("round" (mi (1) (0 3) 0 (ttable)) 3)) 0.065)
-!(assertEqual (py-call ("round" (mi (0 1) (0 3) 0 (ttable)) 3)) 0.236)
-!(assertEqual (mi (0 1) (0 3) 1 (ttable)) 0.815)
+!(assertEqual (py-call ("round" (mi (1) (0 3) 0 (ttable)) 3)) 0.308)
+!(assertEqual (py-call ("round" (mi (0 1) (0 3) 0 (ttable)) 3)) 0.445)
+!(assertEqual (mi (0 1) (0 3) 1 (ttable)) 0.9079999999999999)

--- a/feature-selection/tests/similarity-scorers-test.metta
+++ b/feature-selection/tests/similarity-scorers-test.metta
@@ -18,6 +18,6 @@
 !(assertEqual (jaccardIndex (A B) (B)) 0.5) 
 !(assertEqual (jaccardIndex (A B) (B A)) 1) 
 
-!(assertEqual (py-call ("round" (mi (1) (0 3) 0 (ttable)) 3)) 0.308)
-!(assertEqual (py-call ("round" (mi (0 1) (0 3) 0 (ttable)) 3)) 0.445)
-!(assertEqual (mi (0 1) (0 3) 1 (ttable)) 0.9079999999999999)
+!(assertEqual (py-call ("round" (mi (1) (0 3) 0 (ttable)) 3)) 0.065)
+!(assertEqual (py-call ("round" (mi (0 1) (0 3) 0 (ttable)) 3))  0.236)
+!(assertEqual (mi (0 1) (0 3) 1 (ttable)) 0.815)

--- a/feature-selection/tests/simple-test.metta
+++ b/feature-selection/tests/simple-test.metta
@@ -4,10 +4,11 @@
 !(import! &self feature-selection/simple)
 
 (= (ttable) (mkITable  
-            (cons (cons True (cons True (cons False (cons True (cons True ())))))
-            (cons (cons True (cons False (cons False (cons True (cons True ())))))
-            (cons (cons False (cons True (cons False (cons True (cons False ())))))
-            (cons (cons False (cons False (cons False (cons True (cons False ()))))) ()))))
+            (cons (cons True (cons True (cons False (cons False ()))))
+            (cons (cons True (cons False (cons True (cons False ()))))
+            (cons (cons False (cons False (cons False (cons False ()))))
+            (cons (cons True (cons True (cons True (cons False ())))) 
+            (cons (cons True (cons True (cons False (cons False ())))) ())))))
             
             (cons A (cons B (cons C (cons D (cons Output ())))))))
 
@@ -15,7 +16,7 @@
 !(py-call (random.seed 42))
 
 !(assertEqual (simpleFeatureSelector 0.0 2 False (ttable) ()) ((0 (0 3))))
-!(assertEqual (simpleFeatureSelector 0.0 3 False (ttable) ()) ((0 (0 1 3))))
+!(assertEqual (simpleFeatureSelector 0.0 3 False (ttable) ()) ((0 (0 3 1))))
 !(assertEqual (simpleFeatureSelector 0.0 1 False (ttable) ()) ((0 (0))))
 
 ;; MI threshold 0.5 -- only feature 0 scores above threshold (deterministic)

--- a/moses/tests/input-file-test.metta
+++ b/moses/tests/input-file-test.metta
@@ -84,10 +84,9 @@
 
 (= (inputCsvTable)
    (mkITable
-      ((False False False)
-       (False True  True)
-       (True  False True)
-       (True  True  False))
+      ((False False True True)
+       (False True False True)
+       (False True True False))
       (a b o)))
 
 !(println! ("testing: inputFile loads input.csv as an ITable"))
@@ -105,4 +104,4 @@
 !(assertEqual
    (let $result (moses)
         (second (index-atom (second $result) 0)))
-   0)
+-1)

--- a/optimization/simulated-annealing-algo/test/simulated-annealing-test.metta
+++ b/optimization/simulated-annealing-algo/test/simulated-annealing-test.metta
@@ -70,19 +70,17 @@
 (= (demes) (cons (mkDeme (mkRep (mkKbMap (mkDscMp (((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) )) ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ()) ))))) (mkTree (mkNode AND) (cons (mkKnob (mkNullVex (cons (mkTree (mkNode A) ()) ())) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 0) (cons (mkKnob (mkNullVex (cons (mkTree (mkNode B) ()) ())) (mkLSK (mkDiscKnob (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) ())) 1) ())))) (mkSInstSet ()) (mkDemeId "1")) ()))
 
 (= (table1) (createTruthTableBScore 2 (mkITable
-                         (cons (cons False (cons False (cons False ()))) 
-                         (cons (cons True (cons False (cons False ()))) 
-                         (cons (cons False (cons True (cons False ())))
-                         (cons (cons True (cons True (cons True ()))) ()))))
+                         (cons (cons False (cons True (cons False (cons True ())))) 
+                         (cons (cons False (cons False (cons True (cons True ())))) 
+                         (cons (cons False (cons True (cons False (cons True ())))) ())))
                          (cons A (cons B (cons O ()))))))
 
-(= (itable) (mkITable
-                         (cons (cons False (cons False (cons False ()))) 
-                         (cons (cons True (cons False (cons False ()))) 
-                         (cons (cons False (cons True (cons False ())))
-                         (cons (cons True (cons True (cons True ()))) ()))))
-                         (cons A (cons B (cons O ())))))
-                      
+ (= (itable) (mkITable
+                         (cons (cons False (cons True (cons False (cons True ())))) 
+                         (cons (cons False (cons False (cons True (cons True ())))) 
+                         (cons (cons False (cons False (cons False (cons True ())))) ())))
+                         (cons A (cons B (cons O ())))))   
+
 ;;(: isScored (-> (ScoredInstance Cscore) Bool))
 (= (isScored (mkSInst (mkPair $instance $score))) (~= $score (worstCscore)))
 !(simulated annealing test ----------)

--- a/scoring/precision-bscore.metta
+++ b/scoring/precision-bscore.metta
@@ -295,7 +295,7 @@
 ;; Output:
 ;;   Expression like (filtered_rows filtered_labels) containing only selected features + target
 ; (: extractTable (-> Expression (List (List $a)) (List Symbol) (Expression Expression)))
-(= (extractTable $featureIndices $rows $labels)
+(= (extractTable $featureIndices $columns $labels)
    (let* (
           ;; Target is always last column
           ($targetIndex (- (List.length $labels) 1))
@@ -303,10 +303,10 @@
           ($exprIndices (appendAtom $targetIndex $featureIndices))
 
           ;; Extract selected columns from each row
-          ($filteredRows (zipColumn $exprIndices $rows))
+          ($filteredColumns (zipColumn $exprIndices $columns))
           ;; Extract corresponding labels
           ($filteredLabels (map-atom $exprIndices $each (List.at $each $labels)))
-          ($filteredExpr (List.listToExpr $filteredRows))
+          ($filteredExpr (List.listToExpr $filteredColumns))
           )
      ($filteredExpr $filteredLabels)
    )
@@ -337,7 +337,7 @@
 ;; precision-based classification, accounting for both achievable precision
 ;; and the complexity cost of using multiple features.
 ; (: preScorer (-> Expression (ITable $a) Number Number Number Bool Number Number))
-(= (preScorer $featureIndices (mkITable $rows $labels) $penalty $minAct $maxAct $positive $confi)
+(= (preScorer $featureIndices (mkITable $columns $labels) $penalty $minAct $maxAct $positive $confi)
    (if (== $featureIndices ())
       0.0
       (let* (
@@ -345,11 +345,11 @@
                ($clampedMinAct (clamp $minAct 0.0 1.0))
                ($clampedMaxAct (clamp $maxAct 0.0 1.0))
                
-               (($filteredRows $filteredLabels)  (extractTable $featureIndices $rows $labels))
+               (($filteredColumns $filteredLabels)  (extractTable $featureIndices $columns $labels))
                
-               ($totalWeight (List.length $rows))
+               ($totalWeight (List.length (Table.getColumn 0 $columns)))
                
-               ($precision (precisionBScore $filteredRows $filteredLabels $penalty 
+               ($precision (precisionBScore $filteredColumns $filteredLabels $penalty 
                                           $clampedMinAct $clampedMaxAct $totalWeight))
                
                ;; Apply confidence weighting

--- a/scoring/test/precision-bscore-test.metta
+++ b/scoring/test/precision-bscore-test.metta
@@ -7,29 +7,21 @@
 
 (= (andTable) 
    (mkITable
-     (cons (cons True (cons True (cons True ())))      
-     (cons (cons True (cons False (cons False ())))    
-     (cons (cons False (cons True (cons False ())))    
-     (cons (cons False (cons False (cons False ()))) ()))))
+     (cons (cons True (cons True (cons False (cons False ()))))      
+     (cons (cons True (cons False (cons True (cons False ()))))    
+     (cons (cons True (cons False (cons False (cons False ())))) ())))
      (cons A (cons B (cons Output ())))))
 
-; ;; Test data: Precision Table
+;; Test data: Precision Table
 ; this is directy taken from the moses c++ test file
 ;; reference: https://github.com/opencog/moses/blob/master/tests/moses/precision.csv
-(= (precisionTable)
-   (mkITable
-     (cons (cons False (cons False (cons False ())))  
-     (cons (cons True  (cons False (cons False ())))   
-     (cons (cons False (cons False (cons False ())))  
-     (cons (cons True  (cons False (cons False ())))   
-     (cons (cons True  (cons False (cons False ())))  
-     (cons (cons False (cons False (cons True  ())))  
-     (cons (cons False (cons False (cons True  ())))  
-     (cons (cons False (cons True  (cons True  ())))  
-     (cons (cons False (cons True  (cons True  ())))  
-     (cons (cons False (cons True  (cons True  ()))) ()))))))))))
-     (cons v1 (cons v2 (cons target ())))))
 
+(= (precisionTable)
+   (mkITable 
+     (cons (cons False (cons True (cons False (cons True (cons True (cons False (cons False (cons False (cons False (cons False ())))))))))) 
+     (cons (cons False (cons False (cons False (cons False (cons False (cons False (cons False (cons True (cons True (cons True ()))))))))))
+     (cons (cons False (cons False (cons False (cons False (cons False (cons True (cons True (cons True (cons True (cons True ())))))))))) ())))
+     (cons v1 (cons v2 (cons target ())))))
 
 ; Test of count Table
 ; !(assertEqual (countTable (True True True) 2 ()) (cons ((True True) (1 0)) ()))
@@ -77,10 +69,12 @@
 ;; Test ExtractTable
 
 (= (testRows) 
-            (cons (cons True (cons True (cons False (cons True (cons True ())))))
-            (cons (cons True (cons False (cons False (cons True (cons True ())))))
-            (cons (cons False (cons True (cons False (cons True (cons False ())))))
-            (cons (cons False (cons False (cons False (cons True (cons False ()))))) ())))))
+            (cons (cons True (cons True (cons False (cons False ()))))
+            (cons (cons True (cons False (cons True (cons False ()))))
+            (cons (cons False (cons False (cons False (cons False ()))))
+            (cons (cons True (cons True (cons True (cons True ())))) 
+            (cons (cons True (cons True (cons False (cons False ())))) ()))))))
+            
 (= (testLabels) (cons A (cons B (cons C (cons D (cons Output ()))))))
 
 !(assertEqual (extractTable (0) (testRows) (testLabels))

--- a/scripts/csv_helper.py
+++ b/scripts/csv_helper.py
@@ -90,7 +90,7 @@ def load_boolean_table(path, target_feature=""):
     new_labels.append(target_name)
 
     # Type-check every cell upfront and build a column-major table.
-    num_columns = len(new_labels)
+    num_columns = len(labels)
     validated_columns = [[] for _ in range(num_columns)]
 
     for r_num, row in enumerate(body, start=2):  # +1 for header, 1-indexed

--- a/scripts/csv_helper.py
+++ b/scripts/csv_helper.py
@@ -5,7 +5,7 @@ Called from MeTTa via:
     (py-call (csv_helper.load_boolean_table <path> <target_feature>))
 
 Returns a STRING containing a valid MeTTa S-expression of the form
-    (mkITable <rows-expression-list> <labels-expression-list>)
+    (mkITable <columns-expression-list> <labels-expression-list>)
 which the caller `parse`s back into a MeTTa term.
 
 Every cell is type-checked against a small set of boolean literals; any
@@ -86,9 +86,13 @@ def load_boolean_table(path, target_feature=""):
         target_idx = labels.index(target_feature)
         target_name = target_feature
 
-    # Type-check every cell upfront, build the validated boolean grid with
-    # target column moved to the end.
-    validated_rows = []
+    new_labels = [l for i, l in enumerate(labels) if i != target_idx]
+    new_labels.append(target_name)
+
+    # Type-check every cell upfront and build a column-major table.
+    num_columns = len(new_labels)
+    validated_columns = [[] for _ in range(num_columns)]
+
     for r_num, row in enumerate(body, start=2):  # +1 for header, 1-indexed
         if len(row) != len(labels):
             raise ValueError(
@@ -96,17 +100,19 @@ def load_boolean_table(path, target_feature=""):
                     r=r_num, got=len(row), want=len(labels)
                 )
             )
+
         bools = [
             _to_bool_literal(row[i], r_num, labels[i])
-            for i in range(len(labels))
+            for i in range(num_columns)
         ]
+
         reordered = [b for i, b in enumerate(bools) if i != target_idx]
         reordered.append(bools[target_idx])
-        validated_rows.append(reordered)
 
-    new_labels = [l for i, l in enumerate(labels) if i != target_idx]
-    new_labels.append(target_name)
+        for col_idx, value in enumerate(reordered):
+            validated_columns[col_idx].append(value)
 
-    rows_sexpr = _expr_list(_expr_list(r) for r in validated_rows)
+
+    columns_sexpr = _expr_list(_expr_list(col) for col in validated_columns)
     labels_sexpr = _expr_list(new_labels)
-    return "(mkITable {rows} {labels})".format(rows=rows_sexpr, labels=labels_sexpr)
+    return "(mkITable {rows} {labels})".format( rows=columns_sexpr, labels=labels_sexpr,)


### PR DESCRIPTION
## Description
This PR changes the internal representation of input tables from **row-major** to **column-major** to match how they are used throughout the MOSES evaluation pipeline. The implementation updates the CSV loading pipeline, input table construction, and the dependent utilities and tests to work with the new representation while preserving existing behavior.

The main changes include:
- Store input tables in column-major format instead of row-major.
- Update the CSV loader and input table construction accordingly.
- Update functions that assumed row-major layout to operate on the new representation.
- Update related unit tests and benchmark files.
- Preserve existing functionality while reducing the overhead of repeatedly converting between row-major and column-major layouts.

## Motivation and Context
Most consumers of the input table access data by **column**, while the existing representation stores it by **row**. This causes repeated row-to-column transformations throughout execution, introducing unnecessary overhead.

By storing the table directly in column-major format, these conversions are eliminated, reducing runtime while keeping the external behavior unchanged.

## How Has This Been Tested?
- Updated the affected unit tests to use the new input table representation.
- Verified that all existing tests pass.
- Benchmarked using the **mux6** benchmark with:
  - `nEval = 1000`
  - `maxGen = 1`
  - 5 runs before and 5 runs after the change.

Average wall-clock (`real`) execution time:

| Before | After | Improvement |
|--------:|------:|------------:|
| 57.4 s | 43.8 s | **~24% faster** |

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.