### PR TITLE
feat: make action and perception parameters configurable

### DIFF
--- a/parameters/cli.metta
+++ b/parameters/cli.metta
@@ -96,8 +96,79 @@
 ;; corresponding Number / Bool atoms; bare atoms come back unchanged.
 (= (parse-value () None $name) ())        ;; '--name='
 (= (parse-value () (Some $acc) $name)
-   (flag $name (parse $acc)))
+   (parse-value-atom $acc $name))
 (= (parse-value (cons $h $rest) None $name)
    (parse-value $rest (Some $h) $name))
 (= (parse-value (cons $h $rest) (Some $acc) $name)
-   (parse-value $rest (Some (atom_concat $acc $h)) $name))
+   (parse-value $rest (Some (atom_concat $acc $h))))
+
+;; -------- Parsed value dispatch --------
+;;
+;; Scalar values are handled exactly as before:
+;;
+;;   --capCoef=100      -> 100
+;;   --complexityRatio=3.5 -> 3.5
+;;   --fitness=foo      -> foo
+;;
+;; Comma-separated values are parsed as a tuple:
+;;
+;;   --actions=tttWin,tttBlock,tttCenter
+;;       -> (tttWin tttBlock tttCenter)
+;;
+;; The tuple is quoted because action/perception names are live
+;; MeTTa symbols. Without quote, the tuple can be interpreted as
+;; an expression headed by the first action/perception symbol.
+(= (parse-value-atom $acc $name)
+   (let $chars (atom_chars $acc)
+        (case (contains-comma $chars)
+           (
+             (True (let $items (collapse (parse-comma-list $chars))
+                              (flag $name (quote $items))))
+             (False (flag $name (parse $acc)))))))
+
+;; -------- Comma detection --------
+
+(= (contains-comma ()) False)
+(= (contains-comma (cons $h $rest))
+   (if (== $h ,)
+       True
+       (contains-comma $rest)))
+
+
+;; -------- Comma-separated list parser --------
+;;
+;; Converts:
+;;
+;;   tttWin,tttBlock,tttCenter
+;;
+;; into:
+;;
+;;   (tttWin tttBlock tttCenter)
+;;
+;; Elements are individually passed through parse/1 so normal
+;; scalar parsing remains available for list values.
+
+(= (parse-comma-list $chars)
+   (parse-comma-list $chars None ()))
+
+
+;; End of input with no current element.
+(= (parse-comma-list () None $acc)
+   (reverse $acc))
+
+;; End of input with a final element.
+(= (parse-comma-list () (Some $current) $acc)
+   (reverse (cons-atom (parse $current) $acc)))
+
+;; First character of a new element.
+(= (parse-comma-list (cons $h $rest) None $acc)
+   (if (== $h ,)
+       ()
+       (parse-comma-list $rest (Some $h) $acc)))
+
+;; Continue current element, or terminate it at comma.
+(= (parse-comma-list (cons $h $rest) (Some $current) $acc)
+   (if (== $h ,)
+       (parse-comma-list $rest None (cons-atom (parse $current) $acc))
+       (parse-comma-list $rest
+          (Some (atom_concat $current $h)) $acc)))

--- a/parameters/cli.metta
+++ b/parameters/cli.metta
@@ -1,24 +1,31 @@
 ;; ============================================================
-;;  Command-line override parsing.
+;; Command-line parameter override parsing.
 ;;
-;;  Reads command-line arguments of the form --name=value via
-;;  PeTTa's argv/2 builtin and applies each as (set-param ...).
-;;  Non-matching arguments (script name, -s, etc.) are ignored.
+;; Reads command-line arguments of the form --name=value via
+;; PeTTa's argv/2 builtin and applies recognized overrides through
+;; (set-param ...).
 ;;
-;;  Usage:
-;;    sh run.sh script.metta -s --capCoef=100 --maxDist=6
+;; CLI arguments are optional: when no override is supplied, the
+;; existing values from parameters/defaults.metta remain unchanged.
 ;;
-;;  Invocation:
-;;    The driver script should call !(apply-cli-overrides) once,
-;;    after defaults.metta has loaded.
+;; Non-parameter arguments (script name, -s, etc.) are ignored.
+;;
+;; Usage:
+;;   sh run.sh script.metta -s --capCoef=100 --maxDist=6
+;;
+;; Invocation:
+;;   The driver script should call !(apply-cli-overrides) once,
+;;   after defaults.metta has loaded.
 ;; ============================================================
 
 ;; -------- Top-level entry --------
-;; argv/2 in PeTTa is bound on its second argument but left non-deterministic
-;; on the index: with the index unbound, the underlying nth0 backtracks
-;; through every valid position. Wrapping the call in collapse therefore
-;; gathers every argv entry in a single findall — no need to walk indices
-;; by hand and detect the failing boundary.
+;;
+;; argv/2 is queried with an unbound index, allowing it to backtrack
+;; over all command-line arguments. collapse collects those arguments
+;; into a list.
+;;
+;; Each argument is then passed to try-apply-flag. Arguments that are
+;; not recognized as CLI parameter overrides are ignored.
 (= (apply-cli-overrides)
    (let* (
           ($args (collapse (argv $_)))
@@ -91,43 +98,75 @@
        (parse-value $rest None $acc)
        (parse-name $rest (Some (atom_concat $acc $h)))))
 
-;; Walk chars after '=' accumulating the value atom, then parse it.
-;; parse/1 coerces strings like "100", "3.5", "True" into the
-;; corresponding Number / Bool atoms; bare atoms come back unchanged.
+;; -------- Value parser --------
+;;
+;; Walk chars after '=' accumulating the value atom.
+;;
+;; Scalar values preserve the existing behaviour:
+;;
+;;   100        -> 100
+;;   3.5        -> 3.5
+;;   True       -> True
+;;   hc         -> hc
+;;
+;; Comma-separated values are interpreted as a tuple:
+;;
+;;   a,b,c      -> (a b c)
+;;
+;; The tuple is quoted because action/perception primitives are live
+;; symbols. This preserves the same representation produced by:
+;;
+;;   !(set-param actions
+;;       (quote (tttWin tttBlock tttCenter)))
+;;
+;; Empty values remain invalid, preserving the previous behaviour.
 (= (parse-value () None $name) ())        ;; '--name='
+
 (= (parse-value () (Some $acc) $name)
    (parse-value-atom $acc $name))
+
 (= (parse-value (cons $h $rest) None $name)
    (parse-value $rest (Some $h) $name))
+
 (= (parse-value (cons $h $rest) (Some $acc) $name)
-   (parse-value $rest (Some (atom_concat $acc $h))))
+   (parse-value $rest (Some (atom_concat $acc $h)) $name))
+
 
 ;; -------- Parsed value dispatch --------
 ;;
-;; Scalar values are handled exactly as before:
+;; Decide whether the accumulated value is a scalar or a
+;; comma-separated tuple.
 ;;
-;;   --capCoef=100      -> 100
-;;   --complexityRatio=3.5 -> 3.5
-;;   --fitness=foo      -> foo
+;; Scalar values are parsed normally:
 ;;
-;; Comma-separated values are parsed as a tuple:
+;;   --capCoef=100          -> 100
+;;   --complexityRatio=3.5  -> 3.5
+;;   --fitness=foo          -> foo
+;;
+;; Comma-separated values are converted into a tuple:
 ;;
 ;;   --actions=tttWin,tttBlock,tttCenter
 ;;       -> (tttWin tttBlock tttCenter)
 ;;
-;; The tuple is quoted because action/perception names are live
-;; MeTTa symbols. Without quote, the tuple can be interpreted as
-;; an expression headed by the first action/perception symbol.
+;; The resulting tuple is quoted so that action/perception symbols
+;; are stored as data rather than evaluated as an expression.
+;;
+;; This produces the same parameter representation as:
+;;
+;;   !(set-param actions
+;;       (quote (tttWin tttBlock tttCenter)))
 (= (parse-value-atom $acc $name)
    (let $chars (atom_chars $acc)
         (case (contains-comma $chars)
            (
-             (True (let $items (collapse (parse-comma-list $chars))
-                              (flag $name (quote $items))))
-             (False (flag $name (parse $acc)))))))
+             (True
+                (let $items (parse-comma-list $chars)
+                     (flag $name (quote $items))))
+             (False
+                (flag $name (parse $acc)))))))
 
-;; -------- Comma detection --------
 
+;; Check whether a character list contains a comma.
 (= (contains-comma ()) False)
 (= (contains-comma (cons $h $rest))
    (if (== $h ,)
@@ -145,30 +184,39 @@
 ;;
 ;;   (tttWin tttBlock tttCenter)
 ;;
-;; Elements are individually passed through parse/1 so normal
-;; scalar parsing remains available for list values.
-
+;; Each element is independently passed through parse/1 so that
+;; normal atom/number/bool conversion is preserved for list values.
+;;
+;; $current is the current element being accumulated.
+;; $acc contains already-parsed elements in reverse order.
 (= (parse-comma-list $chars)
    (parse-comma-list $chars None ()))
 
 
-;; End of input with no current element.
+;; End of input: parse the final element and reverse the accumulated
+;; elements so the original CLI ordering is preserved.
 (= (parse-comma-list () None $acc)
    (reverse $acc))
 
-;; End of input with a final element.
 (= (parse-comma-list () (Some $current) $acc)
    (reverse (cons-atom (parse $current) $acc)))
 
-;; First character of a new element.
+;; Comma terminates the current element.
 (= (parse-comma-list (cons $h $rest) None $acc)
    (if (== $h ,)
        ()
-       (parse-comma-list $rest (Some $h) $acc)))
+       (parse-comma-list
+          $rest
+          (Some $h)
+          $acc)))
 
-;; Continue current element, or terminate it at comma.
 (= (parse-comma-list (cons $h $rest) (Some $current) $acc)
    (if (== $h ,)
-       (parse-comma-list $rest None (cons-atom (parse $current) $acc))
-       (parse-comma-list $rest
-          (Some (atom_concat $current $h)) $acc)))
+       (parse-comma-list
+          $rest
+          None
+          (cons-atom (parse $current) $acc))
+       (parse-comma-list
+          $rest
+          (Some (atom_concat $current $h))
+          $acc)))

--- a/parameters/tests/cli-list-override-smoke.metta
+++ b/parameters/tests/cli-list-override-smoke.metta
@@ -1,0 +1,39 @@
+
+;; ============================================================
+;; cli-list-override-smoke.metta
+;;
+;; Manual CLI integration smoke test.
+;;
+;; Verifies the complete path:
+;;
+;;   argv
+;;     -> apply-cli-overrides
+;;     -> parse-flag
+;;     -> set-param
+;;     -> parameter registry
+;;
+;; Run with:
+;;
+;;   run.sh parameters/tests/cli-list-override-smoke.metta -s \
+;;     --actions=tttWin,tttBlock,tttCenter \
+;;     --perceptions=tttCanWin,tttCanBlock,tttCenterFree
+;; ============================================================
+
+!(import! &self ../../utilities/general-helpers)
+!(import! &self ../registry)
+!(import! &self ../defaults)
+!(import! &self ../cli)
+
+;; Apply the actual command-line arguments.
+!(apply-cli-overrides)
+
+;; ---- Verify action override ----
+!(assertEqual
+   (param actions)
+   (tttWin tttBlock tttCenter))
+
+;; ---- Verify perception override ----
+!(assertEqual
+   (param perceptions)
+   (tttCanWin tttCanBlock tttCenterFree))
+

--- a/parameters/tests/cli-override-smoke.metta
+++ b/parameters/tests/cli-override-smoke.metta
@@ -1,0 +1,31 @@
+
+;; ============================================================
+;; cli-override-smoke.metta
+;;
+;; Manual end-to-end smoke test for command-line parameter
+;; overrides.
+;;
+;; Verifies the complete path:
+;;   argv -> apply-cli-overrides -> parse-flag -> set-param
+;;
+;; Run with:
+;;   sh run.sh parameters/tests/cli-override-smoke.metta -s \
+;;     --capCoef=777 \
+;;     --complexityRatio=2.5
+;;
+;; This file is intentionally not executed by run-tests.py
+;; because its filename does not match the automated *-test.metta
+;; convention.
+;; ============================================================
+
+!(import! &self ../../utilities/general-helpers)
+!(import! &self ../registry)
+!(import! &self ../defaults)
+!(import! &self ../cli)
+
+!(apply-cli-overrides)
+
+;; Verify that the supplied CLI values override the defaults.
+!(assertEqual (param capCoef) 777)
+!(assertEqual (param complexityRatio) 2.5)
+

--- a/parameters/tests/cli-override-test.metta
+++ b/parameters/tests/cli-override-test.metta
@@ -1,14 +1,23 @@
-;; Stand-alone manual smoke check for CLI overrides.
-;; Run with extra flags to confirm they land in &params:
-;;   sh run.sh parameters/tests/cli-override-smoke.metta -s --capCoef=777 --complexityRatio=2.5
-;; Not invoked by run-tests.py (file name doesn't match *test.metta).
+
+;; ============================================================
+;; cli-override-test.metta
+;;
+;; Verifies that parameter defaults remain unchanged when no
+;; command-line overrides are supplied.
+;;
+;; This is an automated test and is executed by run-tests.py.
+;; It intentionally does not require CLI arguments.
+;; ============================================================
 
 !(import! &self ../../utilities/general-helpers)
 !(import! &self ../registry)
 !(import! &self ../defaults)
 !(import! &self ../cli)
 
+;; No CLI overrides are supplied.
+;; Defaults from defaults.metta should remain active.
 !(apply-cli-overrides)
 
 !(assertEqual (param capCoef) 50)
 !(assertEqual (param complexityRatio) 3.5)
+

--- a/parameters/tests/cli-test.metta
+++ b/parameters/tests/cli-test.metta
@@ -37,3 +37,12 @@
 !(println! ("testing: try-apply-flag is a no-op for non-flag arguments"))
 !(try-apply-flag something-else)
 !(assertEqual (param capCoef) 77)   ;; unchanged from above
+
+!(assertEqual
+   (parse-comma-list (atom_chars "tttCanWin,tttCanBlock"))
+   (tttCanWin tttCanBlock))
+   
+!(assertEqual
+   (parse-comma-list (atom_chars "tttWin,tttBlock,tttCenter"))
+   (tttWin tttBlock tttCenter))
+


### PR DESCRIPTION
## Description

This PR makes action and perception vocabularies configurable through the existing parameter system.

Users can provide action and perception sets externally, including through command-line arguments, without modifying the generic MOSES implementation when introducing a new action domain.

For example:

```bash
run.sh <experiment>.metta -s \
  --actions=tttWin,tttBlock,tttCenter \
  --perceptions=tttCanWin,tttCanBlock,tttCenterFree
```

These values are parsed and stored as:

```text
(param actions)
(param perceptions)
```

The generic action pipeline consumes the configured vocabularies without depending on a specific action domain.

## Motivation and Context

The action-domain architecture is intended to make MOSES reusable across different action domains.

Previously, introducing a new domain could require modifying code or experiment files to provide the action and perception vocabularies.

This change allows those vocabularies to be supplied through the existing parameter system instead, so users can configure a new action domain without modifying the generic implementation.

CLI overrides are optional. When no overrides are supplied, the existing values from `defaults.metta` remain unchanged, preserving the current behavior of existing experiments.

## How Has This Been Tested?

### Automated tests

`parameters/tests/cli-test.metta` covers:

* Valid `--name=value` parsing
* Malformed CLI arguments
* Scalar values
* Boolean values
* `try-apply-flag`
* Comma-separated parameter values

These tests run as part of the normal automated test suite.

`parameters/tests/cli-override-test.metta` verifies that the existing parameter defaults remain unchanged when no CLI overrides are supplied.

### Manual CLI smoke tests

`parameters/tests/cli-override-smoke.metta` verifies scalar command-line overrides:

```bash
run.sh parameters/tests/cli-override-smoke.metta -s \
  --capCoef=777 \
  --complexityRatio=2.5
```

Expected:

```text
is 777, should 777. ✅
is 2.5, should 2.5. ✅
```

`parameters/tests/cli-list-override-smoke.metta` verifies the complete action/perception override path:

```text
argv
  ↓
apply-cli-overrides
  ↓
parse-flag
  ↓
set-param
  ↓
parameter registry
  ↓
(param actions)
(param perceptions)
```

It is run with:

```bash
run.sh parameters/tests/cli-list-override-smoke.metta -s \
  --actions=tttWin,tttBlock,tttCenter \
  --perceptions=tttCanWin,tttCanBlock,tttCenterFree
```

Expected:

```text
is (tttWin tttBlock tttCenter),
should (tttWin tttBlock tttCenter). ✅

is (tttCanWin tttCanBlock tttCenterFree),
should (tttCanWin tttCanBlock tttCenterFree). ✅
```

The list override smoke test is intentionally a manual test because it requires command-line arguments.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

* [x] My code follows the code style of this project.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
